### PR TITLE
calculate frame duration instead of video duration

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -150,7 +150,7 @@ class AnimateDiffScript(scripts.Script):
                 filename = f"{seq:05}-{res.seed}"
                 video_path = f"{p.outpath_samples}/AnimateDiff/{filename}.gif"
                 video_paths.append(video_path)
-                imageio.mimsave(video_path, video_list, duration=(video_length/fps), loop=loop_number)
+                imageio.mimsave(video_path, video_list, duration=(1/fps), loop=loop_number)
             res.images = video_paths
             self.logger.info("AnimateDiff process end.")
 


### PR DESCRIPTION
Current code calculates the duration of the video (frames / fps = seconds), but the duration parameter of imageio.mimsave is meant to be the duration per frame (1 / fps). See the documentation for the pillow and GIF-PIL backends used by imageio: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#gif-saving

Before, 16 frames at 8 fps generates a GIF with 2000ms duration per frame.
With this change it generates a GIF with 130 ms duration per frame (limited precision rounds up from 125 ms).
```
$ identify --verbose after.gif | grep Delay
  Delay: 13x100
  ...
```