### PR TITLE
Add output format options

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -70,7 +70,7 @@ class AnimateDiffScript(scripts.Script):
                     save_png = gr.Checkbox(value=True, label='Save PNG')
                     save_gif = gr.Checkbox(value=True, label='Save GIF')
                     save_mp4 = gr.Checkbox(value=True, label='Save MP4')
-                    save_txt = gr.Checkbox(value=False, label='Save TXT')
+                    save_txt = gr.Checkbox(value=True, label='Save TXT')
             with gr.Row():
                 optimize_gif = gr.Checkbox(value=False, label='Optimize GIF (requires pygifsicle and gifsicle)')
             with gr.Row():
@@ -146,7 +146,7 @@ class AnimateDiffScript(scripts.Script):
         save_png=True,
         save_gif=True,
         save_mp4=True,
-        save_txt=False,
+        save_txt=True,
         optimize_gif=False,
         loop_number=0,
         video_length=16,
@@ -177,7 +177,7 @@ class AnimateDiffScript(scripts.Script):
         save_png=True,
         save_gif=True,
         save_mp4=True,
-        save_txt=False,
+        save_txt=True,
         optimize_gif=False,
         loop_number=0,
         video_length=16,


### PR DESCRIPTION
- Add checkbox to save individual frames
- Add checkbox to save GIF
- Add checkbox to save MP4
- Move location of saved frames to dated folders under AnimateDiff instead of regular txt2img folder
- Don't save frames by default
- Save GIF by default

Saving as WEBP and WEBM would be nice, but I couldn't get it working.

The UI was rearranged slightly as well. Here it is before:
![feature-output-formats-before](https://github.com/continue-revolution/sd-webui-animatediff/assets/128872140/4b5b146f-0367-4843-8195-c3f3f4c9e39e)

And here it is after:
![feature-output-formats-after](https://github.com/continue-revolution/sd-webui-animatediff/assets/128872140/f1c35ba1-725e-4034-930a-f7faf5adfed3)

