### PR TITLE
Prevent generating two different videos

### DIFF
--- a/motion_module.py
+++ b/motion_module.py
@@ -125,7 +125,7 @@ class TemporalTransformer3DModel(nn.Module):
         self.proj_out = nn.Linear(inner_dim, in_channels)    
     
     def forward(self, hidden_states, encoder_hidden_states=None, attention_mask=None):
-        video_length = hidden_states.shape[0] // 2 # TODO: config this value in scripts
+        video_length = hidden_states.shape[0] // 1 # TODO: config this value in scripts
         batch, channel, height, weight = hidden_states.shape
         residual = hidden_states
 


### PR DESCRIPTION
From my local testing, this fixes an issue with exactly half of frames being separate video. 