### PR TITLE
QOL features and settings, backend cleanup for ease of maintenance, minor bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AnimateDiff for Stable Diffusion Webui
+# AnimateDiff for Stable Diffusion WebUI
 
-This extension aim for integrating [AnimateDiff](https://github.com/guoyww/AnimateDiff/) into [AUTOMATIC1111 Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui). I have tested this extension with WebUI v1.4.1 on Ubuntu 20.04 with NVIDIA 3090. You can generate GIFs in exactly the same way as generating images after enabling this extension.
+This extension aim for integrating [AnimateDiff](https://github.com/guoyww/AnimateDiff/) into [AUTOMATIC1111 Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui). You can generate GIFs in exactly the same way as generating images after enabling this extension.
 
 This extension implements AnimateDiff in a different way. It does not require you to clone the whole SD1.5 repository. It also applied (probably) the least modification to `ldm`, so that you do not need to reload your model weights if you don't want to.
 
@@ -13,90 +13,84 @@ You might also be interested in another extension I created: [Segment Anything f
 ## How to Use
 
 1. Install this extension via link.
-2. Download motion modules from [Google Drive](https://drive.google.com/drive/folders/1EqLC65eR1-W-sGD0Im7fkED6c8GkiNFI) | [HuggingFace](https://huggingface.co/guoyww/animatediff) | [CivitAI](https://civitai.com/models/108836) | [Baidu NetDisk](https://pan.baidu.com/s/18ZpcSM6poBqxWNHtnyMcxg?pwd=et8y). You only need to download one of `mm_sd_v14.ckpt` | `mm_sd_v15.ckpt`. Put the model weights under `sd-webui-animatediff/model/`. DO NOT change model filename.
-3. Go to txt2img if you want to try txt2gif and img2img if you want to try img2gif.
-4. Choose an SD1.5 checkpoint, write prompts, set configurations such as image width/height. If you want to generate multiple GIFs at once, please change batch number, instead of batch size.
-5. Enable AnimateDiff extension, and set up each parameter, and click `Generate`.
+1. Download motion modules and put the model weights under `stable-diffusion-webui/extensions/sd-webui-animatediff/model/`. If you want to use another directory to save the model weights, please go to `Settings/AnimateDiff`. See [model zoo](#motion-module-model-zoo) for a list of available motion modules.
+1. Enable `Pad prompt/negative prompt to be same length` and `Batch cond/uncond` and click `Apply settings` in `Settings`. You must do this to prevent generating two separate unrelated GIFs.
+
+### WebUI
+1. Go to txt2img if you want to try txt2gif and img2img if you want to try img2gif.
+1. Choose an SD1.5 checkpoint, write prompts, set configurations such as image width/height. If you want to generate multiple GIFs at once, please change batch number, instead of batch size.
+1. Enable AnimateDiff extension, and set up each parameter, and click `Generate`.
    1. **Number of frames** — The model is trained with 16 frames, so it’ll give the best results when the number of frames is set to `16`.
    1. **Frames per second** — How many frames (images) are shown every second. If 16 frames are generated at 8 frames per second, your GIF’s duration is 2 seconds.
    1. **Loop number** — How many times the GIF is played. A value of `0` means the GIF never stops playing.
-5. You should see the output GIF on the output gallery. You can access GIF output at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/AnimateDiff`. You can also access image frames at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/{date}`.
+1. You should see the output GIF on the output gallery. You can access GIF output at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/AnimateDiff`. You can also access image frames at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/{date}`.
+
+### API
+[#42](https://github.com/continue-revolution/sd-webui-animatediff/issues/42)
+
+## Motion Module Model Zoo
+- `mm_sd_v14.ckpt` & `mm_sd_v15.ckpt` & `mm_sd_v15_v2.ckpt` by [@guoyww](https://github.com/guoyww): [Google Drive](https://drive.google.com/drive/folders/1EqLC65eR1-W-sGD0Im7fkED6c8GkiNFI) | [HuggingFace](https://huggingface.co/guoyww/animatediff) | [CivitAI](https://civitai.com/models/108836) | [Baidu NetDisk](https://pan.baidu.com/s/18ZpcSM6poBqxWNHtnyMcxg?pwd=et8y)
+- `mm-Stabilized_high.pth` & `mm-Stabbilized_mid.pth` by [@manshoety](https://huggingface.co/manshoety): [HuggingFace](https://huggingface.co/manshoety/AD_Stabilized_Motion/tree/main)
+- `temporaldiff-v1-animatediff.ckpt` by [@CiaraRowles](https://huggingface.co/CiaraRowles): [HuggingFace](https://huggingface.co/CiaraRowles/TemporalDiff/tree/main)
 
 ## Update
 
 - `2023/07/20` [v1.1.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.1.0): fix gif duration, add loop number, remove auto-download, remove xformers, remove instructions on gradio UI, refactor README, add [sponsor](#sponsor) QR code.
 - `2023/07/24` [v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0): fix incorrect insertion of motion modules, add option to change path to save motion modules in Settings/AnimateDiff, fix loading different motion modules.
-- `2023/07/27` [v1.2.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.1): add hash calculation of motion modules (you can disable it in `Settings/AnimateDiff`) 
-
-## TODO
-This TODO list will most likely be resolved sequentially.
-- [ ] greyer sample
-- [ ] other attention optimization (e.g. sdp)
-- [ ] img2img
-- [ ] [token](https://github.com/continue-revolution/sd-webui-animatediff/issues/4)
-- [ ] [shape](https://github.com/continue-revolution/sd-webui-animatediff/issues/3)
-- [ ] [reddit](https://www.reddit.com/r/StableDiffusion/comments/152n2cr/a1111_extension_of_animatediff_is_available/?sort=new)
+- `2023/09/04` [v1.3.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.3.0): support any community models with the same architecture; fix grey problem via [#63](https://github.com/continue-revolution/sd-webui-animatediff/issues/63) (credit to [@TDS4874](https://github.com/TDS4874) and [@opparco](https://github.com/opparco))
+- `2023/09/11` [v1.4.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.0): support official v2 motion module (different architecture: GroupNorm not hacked, UNet middle layer has motion module).    
+    - If you are using V1 motion modules: starting from this version, you will be able to disable hacking GroupNorm in `Settings/AnimateDiff`. If you disable hacking GruopNorm, you will be able to use this extension in `img2img` in all settings, but the generated GIFs will have flickers. In WebUI >=v1.6.0, even if GroupNorm is hacked, you can still use this extension in `img2img` with `--no-half-vae` enabled.
+    - If you are using V2 motion modules: you will always be able to use this extension in `img2img`, regardless of changing that setting or not.
+- `2023/09/14`: [v1.4.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.1): always change `beta`, `alpha_comprod` and `alpha_comprod_prev` to resolve grey problem in other samplers.
 
 ## FAQ
-1.  Q: I am using a remote server which blocks Google. What should I do?
+1.  Q: How much VRAM do I need?
 
-    A: You will have to find a way to download motion modules locally and re-upload to your server.
+    A: Currently, you can run WebUI with this extension via NVIDIA 3090/4090. I cannot guarantee any other variations of GPU. Actual VRAM usage depends on your image size and video frame number. You can try to reduce image size or video frame number to reduce VRAM usage. The default setting (displayed in [Samples/txt2img](#txt2img) section) consumes 12GB VRAM. More VRAM info will be added later.
 
-2.  Q: How much VRAM do I need?
+1.  Q: Can I use SDXL to generate GIFs?
 
-    A: Currently, you can run WebUI with this extension via NVIDIA 3090. I cannot guarantee any other variations of GPU. Actual VRAM usage depends on your image size and video frame number. You can try to reduce image size or video frame number to reduce VRAM usage. The default setting (displayed in [Samples/txt2img](#txt2img) section) consumes 12GB VRAM. More VRAM info will be added later.
+    A: You will have to wait for someone to train SDXL-specific motion modules which will have a different model architecture. This extension essentially inject multiple motion modules into SD1.5 UNet. It does not work for other variations of SD, such as SD2.1 and SDXL.
 
-3.  Q: Can I generate a video instead a GIF?
+1.  Q: Can I generate a video instead a GIF?
 
-    A: Unfortunately, you cannot. This is because a whole batch of images will pass through a transformer module, which prevents us from generating videos sequentially. We look forward to future developments of deep learning for video generation.
+    A: Not at this time, but will be supported via a very huge [output format pull request](https://github.com/continue-revolution/sd-webui-animatediff/pull/54) in the near future. I will merge with some other huge updates.
 
-4.  Q: Can I use SDXL to generate GIFs?
+1.  Q: Can I use this extension to do GIF2GIF? Can I apply ControlNet to this extension? Can I override the limitation of 24/32 frames per generation?
 
-    A: At least at this time, you cannot. This extension essentially inject multiple motion modules into SD1.5 UNet. It does not work for other variations of SD, such as SD2.1 and SDXL. I'm not sure what will happen if you force-add motion modules to SD2.1 or SDXL. Future experiments are needed.
+    A: Not at this time, but will be supported via supporting [AnimateDIFF CLI Prompt Travel](https://github.com/s9roll7/animatediff-cli-prompt-travel) in the near future. This is a huge amount of work and life is busy, so expect to wait for a long time before updating.
 
-5.  Q: Can I use this extension to do gif2gif?
+1.  Q: Can I use xformers, sdp or some other attention optimizations?
 
-    A: Due to the 1-batch behavior of AnimateDiff, it is probably not possible to support gif2gif. However, I need to discuss this with the authors of AnimateDiff.
+    A: Attention optimizations are currently not applied to motion modules, but will applied after a pull request in the near future.
 
-6.  Q: Can I use xformers?
+1.  Q: Can I use this extension to do img2GIF? The current generation result seems pretty static.
 
-    A: Yes, but it will not be applied to AnimateDiff due to [a weird bug](https://github.com/continue-revolution/sd-webui-animatediff/issues/2). I will try other optimizations. Note that xformers will change the GIF you generate.
+    A: The current performance for img2GIF is indeed static. I will look into a [forked](https://github.com/talesofai/AnimateDiff) AnimateDiff repository and see how I can resolve this problem in the near future.
 
-7.  Q: This extension perform worse than [AnimateDiff](https://github.com/guoyww/AnimateDiff/). There seem to be no motion but only glitches. Why?
+1.  Q: How can I reproduce the result in [Samples/txt2img](#txt2img) section?
 
-    A: Because I inserted motion modules to the wrong place inside UNet output blocks. It is a very idiot typo (I wrote a 2 where it was supposed to be 3) but took me days to discover.
-
-8.  Q: How can I reproduce the result in [Samples/txt2img](#txt2img) section?
-
-    A: You must replace [create_random_tensors](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/processing.py#L479-L537) with 
+    A: You must use this logic to initialize random tensors:
     ```python
         torch.manual_seed(<seed>)
         from einops import rearrange
         x = rearrange(torch.randn((4, 16, 64, 64), device=shared.device), 'c f h w -> f c h w')
     ```
-    and retry. A1111 generate random tensors in a completely different way.
 
-9. Q: [v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0) does not work for img2img. Why?
-
-    A: I don't know. I will try to figure out why very soon.
-
-10. Q: [v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0) seems to give a greyer sample compared to [AnimateDiff](https://github.com/guoyww/AnimateDiff/). Why?
-
-    A: I don't know. I will try to figure out why very soon.
 
 ## Samples
 
 ### txt2img
-| AnimateDiff | A1111 |
-| --- | --- |
-| ![image](https://user-images.githubusercontent.com/63914308/255306527-5105afe8-d497-4ab1-b5c4-37540e9601f8.gif) | ![00023-10788741199826055168](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/c35a952a-a127-491b-876d-cda97771f7ee) |
+| AnimateDiff | Extension v1.2.0 | Extension v1.3.0 |
+| --- | --- | --- |
+| ![image](https://user-images.githubusercontent.com/63914308/255306527-5105afe8-d497-4ab1-b5c4-37540e9601f8.gif) | ![00023-10788741199826055168](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/c35a952a-a127-491b-876d-cda97771f7ee) | ![00013-10788741199826055000](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/43b9cf34-dbd1-4120-b220-ea8cb7882272) |
 
-### img2img
-[v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0) does not work for img2img due to some unknown reason. Will be fixed later.
+Note that I did not modify random tensor generation when producing v1.3.0 samples.
+
 
 ## Sponsor
-You can sponsor me via WeChat or Alipay.
+You can sponsor me via WeChat, AliPay or Paypal.
 
-| WeChat | Alipay |
-| --- | --- |
-| ![216aff0250c7fd2bb32eeb4f7aae623](https://user-images.githubusercontent.com/63914308/232824466-21051be9-76ce-4862-bb0d-a431c186fce1.jpg) | ![15fe95b4ada738acf3e44c1d45a1805](https://user-images.githubusercontent.com/63914308/232824545-fb108600-729d-4204-8bec-4fd5cc8a14ec.jpg) |
+| WeChat | AliPay | Paypal |
+| --- | --- | --- |
+| ![216aff0250c7fd2bb32eeb4f7aae623](https://user-images.githubusercontent.com/63914308/232824466-21051be9-76ce-4862-bb0d-a431c186fce1.jpg) | ![15fe95b4ada738acf3e44c1d45a1805](https://user-images.githubusercontent.com/63914308/232824545-fb108600-729d-4204-8bec-4fd5cc8a14ec.jpg) | ![IMG_1419_](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/eaa7b114-a2e6-4ecc-a29f-253ace06d1ea) |

--- a/motion_module.py
+++ b/motion_module.py
@@ -18,7 +18,7 @@ def zero_module(module):
 
 
 class MotionWrapper(nn.Module):
-    def __init__(self, mm_type="mm_sd_v15.ckpt"):
+    def __init__(self, mm_type="mm_sd_v14.ckpt"):
         super().__init__()
         self.down_blocks = nn.ModuleList([])
         self.up_blocks = nn.ModuleList([])

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -3,6 +3,8 @@ import gc
 import gradio as gr
 import imageio
 import torch
+import piexif
+import piexif.helper
 from einops import rearrange
 
 from modules import scripts, images, shared, script_callbacks, hashes
@@ -11,10 +13,10 @@ from modules.processing import StableDiffusionProcessing, Processed
 from scripts.logging_animatediff import logger_animatediff
 from motion_module import MotionWrapper, VanillaTemporalModule
 
-
 from ldm.modules.diffusionmodules.openaimodel import TimestepBlock, TimestepEmbedSequential
 from ldm.modules.diffusionmodules.util import GroupNorm32
 from ldm.modules.attention import SpatialTransformer
+
 def mm_tes_forward(self, x, emb, context=None):
     for layer in self:
         if isinstance(layer, TimestepBlock):
@@ -27,7 +29,6 @@ def mm_tes_forward(self, x, emb, context=None):
 TimestepEmbedSequential.forward = mm_tes_forward
 script_dir = scripts.basedir()
 groupnorm32_original_forward = GroupNorm32.forward
-
 
 class AnimateDiffScript(scripts.Script):
     motion_module: MotionWrapper = None
@@ -54,10 +55,14 @@ class AnimateDiffScript(scripts.Script):
         AnimateDiffScript.motion_module = None
         torch_gc()
         gc.collect()
+        
+    def get_motion_modules_from_folder(self):
+        return [f for f in os.listdir(shared.opts.data.get("animatediff_model_path", "") or os.path.join(script_dir, "model")) if f.lower().endswith('.ckpt') or f.lower().endswith('.safetensors') or f.lower().endswith('.zip')]
 
     def ui(self, is_img2img):
         with gr.Accordion('AnimateDiff', open=False):
-            model = gr.Dropdown(choices=["mm_sd_v15.ckpt", "mm_sd_v14.ckpt"], value="mm_sd_v15.ckpt", label="Motion module", type="value")
+            choices = self.get_motion_modules_from_folder()
+            model = gr.Dropdown(choices=choices, label="Motion module", type="value")
             with gr.Row():
                 enable = gr.Checkbox(value=False, label='Enable AnimateDiff')
                 video_length = gr.Slider(minimum=1, maximum=24, value=16, step=1, label="Number of frames", precision=0)
@@ -71,7 +76,7 @@ class AnimateDiffScript(scripts.Script):
         return enable, loop_number, video_length, fps, model
 
     def inject_motion_modules(self, p: StableDiffusionProcessing, model_name="mm_sd_v15.ckpt"):
-        model_path = os.path.join(shared.opts.data.get("animatediff_model_path", os.path.join(script_dir, "model")), model_name)
+        model_path = os.path.join(shared.opts.data.get("animatediff_model_path","") or os.path.join(script_dir, "model"), model_name)
         if not os.path.isfile(model_path):
             raise RuntimeError("Please download models manually.")
         if AnimateDiffScript.motion_module is None or AnimateDiffScript.motion_module.mm_type != model_name:
@@ -82,7 +87,7 @@ class AnimateDiffScript(scripts.Script):
                     elif model_name == "mm_sd_v15.ckpt":
                         return 'cf16ea656cb16124990c8e2c70a29c793f9841f3a2223073fac8bd89ebd9b69a'
                     else:
-                        raise RuntimeError(f"Unsupported model filename {model_name}. Should be one of mm_sd_v14.ckpt or mm_sd_v15.ckpt")
+                        raise RuntimeError(f"Unsupported model filename {model_name}. Should be one of mm_sd_v14 or mm_sd_v15")
                 if hashes.sha256(model_path, f"AnimateDiff/{model_name}") != get_mm_hash(model_name):
                     raise RuntimeError(f"{model_name} hash mismatch. You probably need to re-download the motion module.")
             self.logger.info(f"Loading motion module {model_name} from {model_path}")
@@ -130,33 +135,73 @@ class AnimateDiffScript(scripts.Script):
         if shared.cmd_opts.lowvram:
             self.unload_motion_module()
 
-    def before_process(self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v15.ckpt"):
+    def before_process(self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
         if enable_animatediff:
             self.logger.info(f"AnimateDiff process start with video Max frames {video_length}, FPS {fps}, duration {video_length/fps},  motion module {model}.")
             assert video_length > 0 and fps > 0, "Video length and FPS should be positive."
             p.batch_size = video_length
             self.inject_motion_modules(p, model)
 
-    def postprocess(self, p: StableDiffusionProcessing, res: Processed, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v15.ckpt"):
+
+    def save_video(self, p, res, loop_number, video_length, fps, video_paths, output_directory, image_itr, generated_filename):
+        video_list = res.images[image_itr:image_itr + video_length]
+        seq = images.get_next_sequence_number(output_directory, "")
+        filename = f"{seq:05}-{generated_filename}"
+        video_path_before_extension = f"{output_directory}/{filename}"
+        video_extension = shared.opts.data.get("animatediff_file_format", "") or "gif"
+        video_path = f"{video_path_before_extension}.{video_extension}"
+        video_paths.append(video_path)
+        video_duration = 1 / fps
+        video_use_lossless_quality = shared.opts.data.get("animatediff_use_lossless_quality", False)
+        video_quality = shared.opts.data.get("animatediff_video_quality", 95)
+        if video_extension != "gif":
+            geninfo = res.infotext(p, res.index_of_first_image)
+            if shared.opts.enable_pnginfo and geninfo is not None:
+                exif_bytes = piexif.dump({
+                        "Exif":{
+                            piexif.ExifIFD.UserComment:piexif.helper.UserComment.dump(geninfo or "", encoding="unicode")}})
+                if video_extension == "webp":
+                    imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number, quality=video_quality, lossless=video_use_lossless_quality, exif=exif_bytes, exact=True)
+                elif video_extension == "apng":
+                    optimize = not video_use_lossless_quality
+                    imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number, optimize=optimize, exif=exif_bytes) #
+        else:
+            imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number)
+
+    def postprocess(self, p: StableDiffusionProcessing, res: Processed, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
         if enable_animatediff:
             self.remove_motion_modules(p)
+            
             video_paths = []
-            self.logger.info("Merging images into GIF.")
+            self.logger.info("Merging images into video.")
+            
+            namegen = images.FilenameGenerator(p, res.seed, res.prompt, res.images[0])
+            
             from pathlib import Path
-            Path(f"{p.outpath_samples}/AnimateDiff").mkdir(exist_ok=True, parents=True)
-            for i in range(res.index_of_first_image, len(res.images), video_length):
-                video_list = res.images[i:i+video_length]
-                seq = images.get_next_sequence_number(f"{p.outpath_samples}/AnimateDiff", "")
-                filename = f"{seq:05}-{res.seed}"
-                video_path = f"{p.outpath_samples}/AnimateDiff/{filename}.gif"
-                video_paths.append(video_path)
-                imageio.mimsave(video_path, video_list, duration=(1/fps), loop=loop_number)
+            output_directory = shared.opts.data.get("animatediff_outdir_videos", "") or f"{p.outpath_samples}/AnimateDiff"
+            if shared.opts.data.get("animatediff_save_to_subdirectory", True):
+                dirname = namegen.apply(shared.opts.data.get("animatediff_directories_filename_pattern","") or "[date]").lstrip(' ').rstrip('\\ /')
+                output_directory = os.path.join(output_directory, dirname)
+            Path(output_directory).mkdir(exist_ok=True, parents=True)
+            
+            generated_filename = namegen.apply(shared.opts.data.get("animatediff_filename_pattern","") or "[seed]").lstrip(' ').rstrip('\\ /')
+            
+            for image_itr in range(res.index_of_first_image, len(res.images), video_length):
+                self.save_video(p, res, loop_number, video_length, fps, video_paths, output_directory, image_itr, generated_filename)
+                
             res.images = video_paths
             self.logger.info("AnimateDiff process end.")
 
 def on_ui_settings():
     section = ('animatediff', "AnimateDiff")
     shared.opts.add_option("animatediff_model_path", shared.OptionInfo(os.path.join(script_dir, "model"), "Path to save AnimateDiff motion modules", gr.Textbox, section=section))
+    shared.opts.add_option("animatediff_use_lossless_quality", shared.OptionInfo(False, "Use lossless compression. Great quality, very high file size. Not recommended. Does not apply to gif.", gr.Checkbox, section=section))
+    shared.opts.add_option("animatediff_video_quality", shared.OptionInfo(95, "Video Quality for webp - Only applies when animatediff_use_lossless_quality is False.", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}, section=section).info("Higher quality results in higher file sizes"))
+    shared.opts.add_option("animatediff_file_format", shared.OptionInfo("gif", "File format for videos", gr.Radio, {"choices": ["gif","webp","apng"]}, section=section).info("gif: Compatible with most browsers and image viewers, generally high filesize, generally low quality.\nwebp: Medium compatibility with browsers and image viewers. How an image viewer implements to webp library can affect how the image quality appears in that image viewer. Best viewed in a modern browser. Generally lower file size with great quality.\napng: Not compatible with many image viewers, but compatible with most modern browsers. Generally slightly larger file size than webp, but also slightly higher quality."))
+    shared.opts.add_option("animatediff_filename_pattern", shared.OptionInfo("[seed]", "Videos filename pattern", section=section).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"))
+    shared.opts.add_option("animatediff_outdir_videos", shared.OptionInfo("", 'Output directory for videos', section=section))
+    shared.opts.add_option("animatediff_save_to_subdirectory", shared.OptionInfo(True, "Save videos to a subdirectory", section=section))
+    shared.opts.add_option("animatediff_directories_filename_pattern", shared.OptionInfo("[date]", "Directory name pattern", section=section).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"))
     shared.opts.add_option("animatediff_check_hash", shared.OptionInfo(True, "Check hash for motion modules. Disable checking if you want to use your own.", gr.Checkbox, section=section))
 
 

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -2,17 +2,26 @@ import os
 import gc
 import gradio as gr
 import imageio
+import ast
 import torch
 import piexif
 import piexif.helper
 from einops import rearrange
+from typing import List, Tuple
+from pathlib import Path  # Added for directory manipulation
 
+# Modules from your webui
 from modules import scripts, images, shared, script_callbacks, hashes
 from modules.devices import torch_gc, device, cpu
 from modules.processing import StableDiffusionProcessing, Processed
+
+# From AnimateDiff extension
 from scripts.logging_animatediff import logger_animatediff
+from scripts import unet_injection
+from scripts.unet_injection import InjectionParams
 from motion_module import MotionWrapper, VanillaTemporalModule
 
+# Modules from ldm
 from ldm.modules.diffusionmodules.openaimodel import TimestepBlock, TimestepEmbedSequential
 from ldm.modules.diffusionmodules.util import GroupNorm32
 from ldm.modules.attention import SpatialTransformer
@@ -26,23 +35,27 @@ def mm_tes_forward(self, x, emb, context=None):
         else:
             x = layer(x)
     return x
+
+# Constants
 TimestepEmbedSequential.forward = mm_tes_forward
-script_dir = scripts.basedir()
-groupnorm32_original_forward = GroupNorm32.forward
+
+EXTENSION_DIRECTORY = scripts.basedir()
+MODULE_NAME = "AnimateDiff"
 
 class AnimateDiffScript(scripts.Script):
     motion_module: MotionWrapper = None
 
     def __init__(self):
         self.logger = logger_animatediff
+        self.ui_controls = []
 
     def title(self):
-        return "AnimateDiff"
+        return MODULE_NAME
 
     def show(self, is_img2img):
         return scripts.AlwaysVisible
 
-    def unload_motion_module(self):
+    def move_motion_module_to_cpu(self):
         self.logger.info("Moving motion module to CPU")
         if AnimateDiffScript.motion_module is not None:
             AnimateDiffScript.motion_module.to(cpu)
@@ -57,91 +70,125 @@ class AnimateDiffScript(scripts.Script):
         gc.collect()
         
     def get_motion_modules_from_folder(self):
-        return [f for f in os.listdir(shared.opts.data.get("animatediff_model_path", "") or os.path.join(script_dir, "model")) if f.lower().endswith('.ckpt') or f.lower().endswith('.safetensors') or f.lower().endswith('.zip')]
-
-    def ui(self, is_img2img):
+        return [f for f in os.listdir(shared.opts.data.get("animatediff_model_path", "") or 
+                                      os.path.join(EXTENSION_DIRECTORY, "model")) if not f.lower().endswith('.gitkeep')]   
+        
+    def setup_ui_controls(self):
+        # Setup UI controls
         with gr.Accordion('AnimateDiff', open=False):
             choices = self.get_motion_modules_from_folder()
             model = gr.Dropdown(choices=choices, label="Motion module", type="value")
             with gr.Row():
                 enable = gr.Checkbox(value=False, label='Enable AnimateDiff')
                 video_length = gr.Slider(minimum=1, maximum=24, value=16, step=1, label="Number of frames", precision=0)
-                fps = gr.Number(value=8, label="Frames per second (FPS)", precision=0)
-                loop_number = gr.Number(minimum=0, value=0, label="Display loop number (0 = infinite loop)", precision=0)
+                fps = gr.Number(minimum=1, value=8, label="FPS", info= "(Frames per second)", precision=0)
+                loop_number = gr.Number(minimum=0, value=0, label="Display loop number", info="(0 = infinite loop)", precision=0)
             with gr.Row():
                 unload = gr.Button(value="Move motion module to CPU (default if lowvram)")
                 remove = gr.Button(value="Remove motion module from any memory")
-                unload.click(fn=self.unload_motion_module)
+                unload.click(fn=self.move_motion_module_to_cpu)
                 remove.click(fn=self.remove_motion_module)
-        return enable, loop_number, video_length, fps, model
+        self.ui_controls = enable, loop_number, video_length, fps, model
+        return self.ui_controls
+        
+    def make_controls_compatible_with_infotext_copy_paste(self, ui_controls = []):
+        # Set up controls to be copy-pasted using infotext
+        infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
+        paste_field_names: List[str] = []
+        for control in ui_controls:
+            control_locator = get_control_locator(control.label)
+            infotext_fields.append((control, control_locator))
+            paste_field_names.append(control_locator)
+        self.infotext_fields = infotext_fields
+        self.paste_field_names = paste_field_names 
+        
+        return ui_controls
 
-    def inject_motion_modules(self, p: StableDiffusionProcessing, model_name="mm_sd_v15.ckpt"):
+    def ui(self, is_img2img):
+        return self.make_controls_compatible_with_infotext_copy_paste(self.setup_ui_controls())
+    
+    def get_unet(self, p):
+        return p.sd_model.model.diffusion_model
+    
+    def inject_motion_module_to_unet(self, p: StableDiffusionProcessing, injection_params: InjectionParams):               
+        unet = self.get_unet(p)
+        motion_module = AnimateDiffScript.motion_module
+        
+        unet_injection.hack_groupnorm(injection_params)
+        
+        unet_injection.inject_motion_module_to_unet(unet, motion_module, injection_params)
+            
+    def eject_motion_module_to_unet(self, p: StableDiffusionProcessing):
+        unet = self.get_unet(p)
+        
+        unet_injection.eject_motion_module_from_unet(unet)
+            
+        unet_injection.restore_original_groupnorm()
+            
+        if shared.cmd_opts.lowvram:
+            self.move_motion_module_to_cpu()
+
+    def load_motion_module_and_inject_motion_module_to_unet(
+            self, p: StableDiffusionProcessing, injection_params: InjectionParams, model_name="mm_sd_v15.ckpt"):
         model_path = os.path.join(shared.opts.data.get("animatediff_model_path","") or os.path.join(script_dir, "model"), model_name)
         if not os.path.isfile(model_path):
             raise RuntimeError("Please download models manually.")
+        
         if AnimateDiffScript.motion_module is None or AnimateDiffScript.motion_module.mm_type != model_name:
             if shared.opts.data.get("animatediff_check_hash", True):
-                def get_mm_hash(model_name="mm_sd_v15.ckpt"):
-                    if model_name == "mm_sd_v14.ckpt":
-                        return 'aa7fd8a200a89031edd84487e2a757c5315460eca528fa70d4b3885c399bffd5'
-                    elif model_name == "mm_sd_v15.ckpt":
-                        return 'cf16ea656cb16124990c8e2c70a29c793f9841f3a2223073fac8bd89ebd9b69a'
-                    else:
-                        raise RuntimeError(f"Unsupported model filename {model_name}. Should be one of mm_sd_v14 or mm_sd_v15")
-                if hashes.sha256(model_path, f"AnimateDiff/{model_name}") != get_mm_hash(model_name):
+                if get_model_hash(model_path, model_name) != get_expected_hash(model_name):
                     raise RuntimeError(f"{model_name} hash mismatch. You probably need to re-download the motion module.")
+                
             self.logger.info(f"Loading motion module {model_name} from {model_path}")
             mm_state_dict = torch.load(model_path, map_location=device)
-            AnimateDiffScript.motion_module = MotionWrapper(model_name)
+            AnimateDiffScript.motion_module = MotionWrapper(mm_state_dict, model_name)
             missed_keys = AnimateDiffScript.motion_module.load_state_dict(mm_state_dict)
             self.logger.warn(f"Missing keys {missed_keys}")
-        AnimateDiffScript.motion_module.to(device)
-        unet = p.sd_model.model.diffusion_model
-        self.logger.info(f"Hacking GroupNorm32 forward function.")
-        def groupnorm32_mm_forward(self, x):
-            x = rearrange(x, '(b f) c h w -> b c f h w', b=2)
-            x = groupnorm32_original_forward(self, x)
-            x = rearrange(x, 'b c f h w -> (b f) c h w', b=2)
-            return x
-        GroupNorm32.forward = groupnorm32_mm_forward
-        self.logger.info(f"Injecting motion module {model_name} into SD1.5 UNet input blocks.")
-        for mm_idx, unet_idx in enumerate([1, 2, 4, 5, 7, 8, 10, 11]):
-            mm_idx0, mm_idx1 = mm_idx // 2, mm_idx % 2
-            unet.input_blocks[unet_idx].append(AnimateDiffScript.motion_module.down_blocks[mm_idx0].motion_modules[mm_idx1])
-        self.logger.info(f"Injecting motion module {model_name} into SD1.5 UNet output blocks.")
-        for unet_idx in range(12):
-            mm_idx0, mm_idx1 = unet_idx // 3, unet_idx % 3
-            if unet_idx % 3 == 2 and unet_idx != 11:
-                unet.output_blocks[unet_idx].insert(-1, AnimateDiffScript.motion_module.up_blocks[mm_idx0].motion_modules[mm_idx1])
-            else:
-                unet.output_blocks[unet_idx].append(AnimateDiffScript.motion_module.up_blocks[mm_idx0].motion_modules[mm_idx1])
-        self.logger.info(f"Injection finished.")
+            AnimateDiffScript.motion_module.to(device)
+        self.inject_motion_module_to_unet(p, injection_params)
+            
+    def get_model_hash(self, model_path, model_name):
+        return hashes.sha256(model_path, f"AnimateDiff/{model_name}")
 
+    def get_expected_hash(self, model_name):
+        if model_name == "mm_sd_v14.ckpt":
+            return 'aa7fd8a200a89031edd84487e2a757c5315460eca528fa70d4b3885c399bffd5'
+        elif model_name == "mm_sd_v15.ckpt":
+            return 'cf16ea656cb16124990c8e2c70a29c793f9841f3a2223073fac8bd89ebd9b69a'
+        else:
+            raise RuntimeError(f"Unsupported model filename {model_name}. Should be one of mm_sd_v14 or mm_sd_v15")
+        
+    def serialize_args_to_infotext(self, p: StableDiffusionProcessing):
+        # Serialize Animatediff UI controls for infotext and add them to p.extra_generation_params
+        # Get the control values from the script_args instead of the controls directly because they don't update for some reason
+        control_params = {}   
+        control_count = 0
+        for control in self.ui_controls:
+            control_params[control.label] = p.script_args[self.args_from + control_count]
+            control_count += 1
+            
+        if len(control_params) > 0:
+            p.extra_generation_params[MODULE_NAME] = f"{control_params}"
 
-    def remove_motion_modules(self, p: StableDiffusionProcessing):
-        unet = p.sd_model.model.diffusion_model
-        self.logger.info(f"Removing motion module from SD1.5 UNet input blocks.")
-        for unet_idx in [1, 2, 4, 5, 7, 8, 10, 11]:
-            unet.input_blocks[unet_idx].pop(-1)
-        self.logger.info(f"Removing motion module from SD1.5 UNet output blocks.")
-        for unet_idx in range(12):
-            if unet_idx % 3 == 2 and unet_idx != 11:
-                unet.output_blocks[unet_idx].pop(-2)
-            else:
-                unet.output_blocks[unet_idx].pop(-1)
-        self.logger.info(f"Restoring GroupNorm32 forward function.")
-        GroupNorm32.forward = groupnorm32_original_forward
-        self.logger.info(f"Removal finished.")
-        if shared.cmd_opts.lowvram:
-            self.unload_motion_module()
-
-    def before_process(self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
+    def before_process(
+            self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
         if enable_animatediff:
             self.logger.info(f"AnimateDiff process start with video Max frames {video_length}, FPS {fps}, duration {video_length/fps},  motion module {model}.")
             assert video_length > 0 and fps > 0, "Video length and FPS should be positive."
             p.batch_size = video_length
-            self.inject_motion_modules(p, model)
-
+            
+            injection_params = InjectionParams(
+                video_length=video_length,
+                unlimited_area_hack=False,
+            )
+            self.load_motion_module_and_inject_motion_module_to_unet(p, injection_params, model)
+             
+            self.serialize_args_to_infotext(p)
+                
+    def postprocess_batch_list(
+            self, p, pp, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt", **kwargs):
+        if enable_animatediff:
+            p.main_prompt = p.all_prompts[0] ## Ensure the video's infotext displays correctly below the video
 
     def save_video(self, p, res, loop_number, video_length, fps, video_paths, output_directory, image_itr, generated_filename):
         video_list = res.images[image_itr:image_itr + video_length]
@@ -154,23 +201,31 @@ class AnimateDiffScript(scripts.Script):
         video_duration = 1 / fps
         video_use_lossless_quality = shared.opts.data.get("animatediff_use_lossless_quality", False)
         video_quality = shared.opts.data.get("animatediff_video_quality", 95)
-        if video_extension != "gif":
-            geninfo = res.infotext(p, res.index_of_first_image)
-            if shared.opts.enable_pnginfo and geninfo is not None:
+        
+        geninfo = res.infotext(p, res.index_of_first_image)
+        use_geninfo = shared.opts.enable_pnginfo and geninfo is not None
+            
+        if video_extension == "gif":
+            optimize = not video_use_lossless_quality
+            imageio.mimsave(
+                video_path, video_list, duration=video_duration, loop=loop_number, optimize=optimize, 
+                comment=(geninfo if use_geninfo else ""))
+        elif video_extension == "webp":
+            if use_geninfo:
                 exif_bytes = piexif.dump({
                         "Exif":{
-                            piexif.ExifIFD.UserComment:piexif.helper.UserComment.dump(geninfo or "", encoding="unicode")}})
-                if video_extension == "webp":
-                    imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number, quality=video_quality, lossless=video_use_lossless_quality, exif=exif_bytes, exact=True)
-                elif video_extension == "apng":
-                    optimize = not video_use_lossless_quality
-                    imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number, optimize=optimize, exif=exif_bytes) #
-        else:
-            imageio.mimsave(video_path, video_list, duration=video_duration, loop=loop_number)
+                            piexif.ExifIFD.UserComment:piexif.helper.UserComment.dump(geninfo, encoding="unicode")}})
+            imageio.mimsave(
+                video_path, video_list, duration=video_duration, loop=loop_number, 
+                quality=video_quality, lossless=video_use_lossless_quality, exif=(exif_bytes if use_geninfo else b''))
 
-    def postprocess(self, p: StableDiffusionProcessing, res: Processed, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
-        if enable_animatediff:
-            self.remove_motion_modules(p)
+    def postprocess(
+            self, p: StableDiffusionProcessing, res: Processed, 
+            enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v14.ckpt"):
+        
+        self.eject_motion_module_to_unet(p)
+            
+        if enable_animatediff and shared.opts.data.get("animatediff_always_save_videos", True):
             
             video_paths = []
             self.logger.info("Merging images into video.")
@@ -180,29 +235,45 @@ class AnimateDiffScript(scripts.Script):
             from pathlib import Path
             output_directory = shared.opts.data.get("animatediff_outdir_videos", "") or f"{p.outpath_samples}/AnimateDiff"
             if shared.opts.data.get("animatediff_save_to_subdirectory", True):
-                dirname = namegen.apply(shared.opts.data.get("animatediff_directories_filename_pattern","") or "[date]").lstrip(' ').rstrip('\\ /')
+                dirname = namegen.apply(shared.opts.data.get("animatediff_subdirectories_filename_pattern","") or 
+                                        "[date]").lstrip(' ').rstrip('\\ /')
                 output_directory = os.path.join(output_directory, dirname)
             Path(output_directory).mkdir(exist_ok=True, parents=True)
             
-            generated_filename = namegen.apply(shared.opts.data.get("animatediff_filename_pattern","") or "[seed]").lstrip(' ').rstrip('\\ /')
+            generated_filename = namegen.apply(shared.opts.data.get("animatediff_filename_pattern","") or 
+                                               "[seed]").lstrip(' ').rstrip('\\ /')
             
             for image_itr in range(res.index_of_first_image, len(res.images), video_length):
                 self.save_video(p, res, loop_number, video_length, fps, video_paths, output_directory, image_itr, generated_filename)
                 
             res.images = video_paths
             self.logger.info("AnimateDiff process end.")
+        
+def get_control_locator(control_label):
+    return f"{MODULE_NAME} {control_label}"
+            
+def infotext_pasted(infotext, results):
+    """Parse AnimateDiff infotext string and write result to `results` dict."""
+    
+    if not shared.opts.data.get("animatediff_copy_paste_infotext"):
+        return 
+    
+    for k, v in results.items():
+        if not k.startswith(MODULE_NAME):
+            continue
 
-def on_ui_settings():
-    section = ('animatediff', "AnimateDiff")
-    shared.opts.add_option("animatediff_model_path", shared.OptionInfo(os.path.join(script_dir, "model"), "Path to save AnimateDiff motion modules", gr.Textbox, section=section))
-    shared.opts.add_option("animatediff_use_lossless_quality", shared.OptionInfo(False, "Use lossless compression. Great quality, very high file size. Not recommended. Does not apply to gif.", gr.Checkbox, section=section))
-    shared.opts.add_option("animatediff_video_quality", shared.OptionInfo(95, "Video Quality for webp - Only applies when animatediff_use_lossless_quality is False.", gr.Slider, {"minimum": 1, "maximum": 100, "step": 1}, section=section).info("Higher quality results in higher file sizes"))
-    shared.opts.add_option("animatediff_file_format", shared.OptionInfo("gif", "File format for videos", gr.Radio, {"choices": ["gif","webp","apng"]}, section=section).info("gif: Compatible with most browsers and image viewers, generally high filesize, generally low quality.\nwebp: Medium compatibility with browsers and image viewers. How an image viewer implements to webp library can affect how the image quality appears in that image viewer. Best viewed in a modern browser. Generally lower file size with great quality.\napng: Not compatible with many image viewers, but compatible with most modern browsers. Generally slightly larger file size than webp, but also slightly higher quality."))
-    shared.opts.add_option("animatediff_filename_pattern", shared.OptionInfo("[seed]", "Videos filename pattern", section=section).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"))
-    shared.opts.add_option("animatediff_outdir_videos", shared.OptionInfo("", 'Output directory for videos', section=section))
-    shared.opts.add_option("animatediff_save_to_subdirectory", shared.OptionInfo(True, "Save videos to a subdirectory", section=section))
-    shared.opts.add_option("animatediff_directories_filename_pattern", shared.OptionInfo("[date]", "Directory name pattern", section=section).link("wiki", "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"))
-    shared.opts.add_option("animatediff_check_hash", shared.OptionInfo(True, "Check hash for motion modules. Disable checking if you want to use your own.", gr.Checkbox, section=section))
-
-
-script_callbacks.on_ui_settings(on_ui_settings)
+        assert isinstance(v, str), f"Expect string but got {v}."
+        try:
+            parsed_dictionary = ast.literal_eval(v)
+            logger_animatediff.debug(parsed_dictionary)
+            for field, value in parsed_dictionary.items():
+                logger_animatediff.debug(f"{field} and {value}")
+                results[get_control_locator(field)] = value
+            results.pop(MODULE_NAME)
+        except Exception:
+            logger_animatediff.warn(
+                f"Failed to parse infotext, legacy format infotext is no longer supported:\n{v}"
+            )
+        break
+     
+script_callbacks.on_infotext_pasted(infotext_pasted)

--- a/scripts/settings_animatediff.py
+++ b/scripts/settings_animatediff.py
@@ -1,0 +1,128 @@
+import os
+import gc
+import gradio as gr
+
+from modules import scripts, script_callbacks, shared
+
+from scripts.logging_animatediff import logger_animatediff
+
+EXTENSION_DIRECTORY = scripts.basedir()
+
+ANIMATEDIFF_SETTINGS_SECTION = ('animatediff', "AnimateDiff")
+
+# Function to create an option with title and info
+def make_option(option_name, option_info):
+    option = shared.OptionInfo(
+        option_info["default"], option_info["title"], 
+        option_info["component_type"], option_info.get("component_args", {}), 
+        section=ANIMATEDIFF_SETTINGS_SECTION)
+    
+    if option_info.get("info") is not None:
+        option.info(option_info.get("info"))
+    if option_info.get("wiki_link") is not None:
+        option.link("wiki", option_info.get("wiki_link"))
+    
+    shared.opts.add_option(option_name, option)
+     
+def get_file_format_info_text():
+    return "gif: Compatible with most browsers and image viewers, generally high filesize, generally low quality. \
+    webp: Medium compatibility with browsers and image viewers. \
+    How an image viewer implements to webp library can affect how the image quality appears in that image viewer. \
+    Best viewed in a modern browser. Generally lower file size with great quality."
+    
+def get_video_quality_info_text():
+    return "Only applies when animatediff_use_lossless_quality is False. Higher quality results in higher file sizes. Does not apply to gif."
+    
+def get_name_pattern_wiki_link():
+    return "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"
+
+def on_ui_settings():
+
+    # Define options in a dictionary
+    animatediff_options = {
+        "animatediff_model_path": {
+            "default": os.path.join(EXTENSION_DIRECTORY, "model"),
+            "title": "Path to save AnimateDiff motion modules",
+            "component_type": gr.Textbox,
+            "info": None,
+            "wiki_link": None
+        },
+        "animatediff_always_save_videos": {
+            "default": True,
+            "title": "Always save generated videos",
+            "component_type": gr.Checkbox,
+            "info": None,
+            "wiki_link": None
+        },
+        "animatediff_file_format": {
+            "default": "gif",
+            "title": "File format for videos",
+            "component_type": gr.Radio,
+            "component_args": {"choices": ["gif", "webp"]},
+            "info": get_file_format_info_text(),
+            "wiki_link": None
+        },
+        "animatediff_use_lossless_quality": {
+            "default": False,
+            "title": "Use lossless quality",
+            "component_type": gr.Checkbox,
+            "info": "Great quality, very high file size. Not recommended.",
+            "wiki_link": None
+        },
+        "animatediff_video_quality": {
+            "default": 95,
+            "title": "Video Quality for webp",
+            "component_type": gr.Slider,
+            "component_args": {"minimum": 1, "maximum": 100, "step": 1},
+            "info":  get_video_quality_info_text(),
+            "wiki_link": None
+        },
+        "animatediff_filename_pattern": {
+            "default": "[seed]",
+            "title": "Videos filename pattern",
+            "component_type": gr.Textbox,
+            "info": None,
+            "wiki_link": get_name_pattern_wiki_link()
+        },
+        "animatediff_outdir_videos": {
+            "default": "",
+            "title": "Output directory for videos",
+            "component_type": gr.Textbox,
+            "info": "Leave blank to place in a subfolder named 'AnimateDiff' inside of txt2img-images or img2img-images folders.",
+            "wiki_link": None
+        },
+        "animatediff_save_to_subdirectory": {
+            "default": True,
+            "title": "Save videos to a subdirectory",
+            "component_type": gr.Checkbox,
+            "info": "If True, put videos in a subfolder named based on animatediff_subdirectories_filename_pattern",
+            "wiki_link": None
+        },
+        "animatediff_subdirectories_filename_pattern": {
+            "default": "[date]",
+            "title": "Subdirectory name pattern",
+            "component_type": gr.Textbox,
+            "info": None,
+            "wiki_link": get_name_pattern_wiki_link()
+        },
+        "animatediff_copy_paste_infotext": {
+            "default": True,
+            "title": "Copy-paste from infotext",
+            "component_type": gr.Checkbox,
+            "info": "If True, AnimateDiff data saved to infotext and pnginfo will be applied when using buttons like 'Send to txt2img'.",
+            "wiki_link": None
+        },
+        "animatediff_check_hash": {
+            "default": False,
+            "title": "Check hash for motion modules.",
+            "component_type": gr.Checkbox,
+            "info": "Disable checking if you want to use your own.",
+            "wiki_link": None
+        }
+    }
+    
+    # Create options
+    for option_name, option_info in animatediff_options.items():
+        make_option(option_name, option_info)
+
+script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/settings_animatediff.py
+++ b/scripts/settings_animatediff.py
@@ -36,6 +36,11 @@ def get_video_quality_info_text():
 def get_name_pattern_wiki_link():
     return "https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Custom-Images-Filename-Name-and-Subdirectory"
 
+def get_hack_groupnorm_info_text():
+    return "Check if you want to hack GroupNorm. By default, V1 hacks GroupNorm, which avoids a performance degradation. \
+        If you choose not to hack GroupNorm for V1, you will be able to use this extension in img2img in all cases, but the generated video will flicker. \
+        V2 does not hack GroupNorm, so that this option will not influence v2 inference."
+
 def on_ui_settings():
 
     # Define options in a dictionary
@@ -112,11 +117,11 @@ def on_ui_settings():
             "info": "If True, AnimateDiff data saved to infotext and pnginfo will be applied when using buttons like 'Send to txt2img'.",
             "wiki_link": None
         },
-        "animatediff_check_hash": {
-            "default": False,
-            "title": "Check hash for motion modules.",
+        "animatediff_hack_gn": {
+            "default": True,
+            "title": "Hack GroupNorm",
             "component_type": gr.Checkbox,
-            "info": "Disable checking if you want to use your own.",
+            "info": get_hack_groupnorm_info_text(),
             "wiki_link": None
         }
     }

--- a/scripts/unet_injection.py
+++ b/scripts/unet_injection.py
@@ -23,6 +23,7 @@ from ldm.modules.attention import SpatialTransformer
 #############################################
 #### Code Injection #########################
 MM_INJECTED_ATTR = "_mm_injected"
+
 GROUPNORM32_ORIGINAL_FORWARD = GroupNorm32.forward
 
 TIMESTEP_ORIGINAL_FORWARD = TimestepEmbedSequential.forward

--- a/scripts/unet_injection.py
+++ b/scripts/unet_injection.py
@@ -1,0 +1,98 @@
+import os
+import gc
+import ast
+import torch
+from torch import Tensor
+from torch.nn.functional import group_norm
+from einops import rearrange
+from typing import List, Tuple
+
+# From AnimateDiff extension
+from scripts.logging_animatediff import logger_animatediff
+from motion_module import MotionWrapper, VanillaTemporalModule
+
+# Modules from ldm
+from ldm.modules.diffusionmodules.openaimodel import TimestepBlock, TimestepEmbedSequential
+from ldm.modules.diffusionmodules.util import GroupNorm32
+from ldm.modules.attention import SpatialTransformer
+
+#############################################
+#### Code Injection #########################
+MM_INJECTED_ATTR = "_mm_injected"
+GROUPNORM32_ORIGINAL_FORWARD = GroupNorm32.forward
+
+class InjectionParams:
+    def __init__(self, video_length: int, unlimited_area_hack: bool) -> None:
+        self.video_length = video_length
+        self.unlimited_area_hack = unlimited_area_hack
+
+def is_mm_injected_into_model(model):
+    return hasattr(model.model.diffusion_model, MM_INJECTED_ATTR)
+
+def get_mm_injected_params(model) -> InjectionParams:
+    return getattr(model.model.diffusion_model, MM_INJECTED_ATTR)
+
+def set_mm_injected_params(model, injection_params: InjectionParams):
+    setattr(model.model.diffusion_model, MM_INJECTED_ATTR, injection_params)
+    
+def groupnorm_mm_factory(params: InjectionParams):
+    def groupnorm_mm_forward(self, input):
+        # axes_factor normalizes batch based on total conds and unconds passed in batch;
+        # the conds and unconds per batch can change based on VRAM optimizations that may kick in
+        axes_factor = input.size(0)//params.video_length
+
+        input = rearrange(input, "(b f) c h w -> b c f h w", b=axes_factor)
+        input = group_norm(input, self.num_groups, self.weight, self.bias, self.eps)
+        input = rearrange(input, "b c f h w -> (b f) c h w", b=axes_factor)
+        return input
+    return groupnorm_mm_forward
+
+def hack_groupnorm(params: InjectionParams):
+    GroupNorm32.forward = groupnorm_mm_factory(params)
+    
+def restore_original_groupnorm():
+    logger_animatediff.info(f"Restoring GroupNorm32 forward function.")
+    GroupNorm32.forward = GROUPNORM32_ORIGINAL_FORWARD
+
+def inject_motion_module_to_unet(unet, motion_module: MotionWrapper, injection_params: InjectionParams):
+    logger_animatediff.info(f"Injecting motion module into UNet input blocks.")
+    for mm_idx, unet_idx in enumerate([1, 2, 4, 5, 7, 8, 10, 11]):
+        mm_idx0, mm_idx1 = mm_idx // 2, mm_idx % 2
+        unet.input_blocks[unet_idx].append(
+            motion_module.down_blocks[mm_idx0].motion_modules[mm_idx1]
+        )
+
+    logger_animatediff.info(f"Injecting motion module into UNet output blocks.")
+    for unet_idx in range(12):
+        mm_idx0, mm_idx1 = unet_idx // 3, unet_idx % 3
+        if unet_idx % 3 == 2 and unet_idx != 11:
+            unet.output_blocks[unet_idx].insert(
+                -1, motion_module.up_blocks[mm_idx0].motion_modules[mm_idx1]
+            )
+        else:
+            unet.output_blocks[unet_idx].append(
+                motion_module.up_blocks[mm_idx0].motion_modules[mm_idx1]
+            )
+
+    if motion_module.mid_block is not None:
+        logger_animatediff.info(f"Injecting motion module into UNet middle blocks.")
+        unet.middle_block.insert(-1, motion_module.mid_block.motion_modules[0]) # only 1 VanillaTemporalModule
+    setattr(unet, MM_INJECTED_ATTR, injection_params)
+
+def eject_motion_module_from_unet(unet):
+    logger_animatediff.info(f"Ejecting motion module from UNet input blocks.")
+    for unet_idx in [1, 2, 4, 5, 7, 8, 10, 11]:
+        unet.input_blocks[unet_idx].pop(-1)
+
+    logger_animatediff.info(f"Ejecting motion module from UNet output blocks.")
+    for unet_idx in range(12):
+        if unet_idx % 3 == 2 and unet_idx != 11:
+            unet.output_blocks[unet_idx].pop(-2)
+        else:
+            unet.output_blocks[unet_idx].pop(-1)
+    
+    if len(unet.middle_block) > 3: # SD1.5 UNet has 3 expected middle_blocks - more means injected
+        logger_animatediff.info(f"Ejecting motion module from UNet middle blocks.")
+        unet.middle_block.pop(-2)
+    delattr(unet, MM_INJECTED_ATTR)
+    

--- a/scripts/unet_injection.py
+++ b/scripts/unet_injection.py
@@ -11,6 +11,10 @@ from typing import List, Tuple
 from scripts.logging_animatediff import logger_animatediff
 from motion_module import MotionWrapper, VanillaTemporalModule
 
+# From webui
+from modules import shared
+from modules.devices import torch_gc, device, cpu
+
 # Modules from ldm
 from ldm.modules.diffusionmodules.openaimodel import TimestepBlock, TimestepEmbedSequential
 from ldm.modules.diffusionmodules.util import GroupNorm32
@@ -22,6 +26,9 @@ MM_INJECTED_ATTR = "_mm_injected"
 GROUPNORM32_ORIGINAL_FORWARD = GroupNorm32.forward
 
 TIMESTEP_ORIGINAL_FORWARD = TimestepEmbedSequential.forward
+
+# DDIM alpha
+ORIGINAL_DDIM_BETAS = dict()
 
 class InjectionParams:
     def __init__(self, video_length: int, unlimited_area_hack: bool) -> None:
@@ -74,19 +81,31 @@ def hack_timestep():
 def restore_original_timestep():
     logger_animatediff.info(f"Restoring TimestepEmbedSequential.forward function.")
     TimestepEmbedSequential.forward = TIMESTEP_ORIGINAL_FORWARD
+    
+def get_unet_input_block_indices():
+    return [1, 2, 4, 5, 7, 8, 10, 11]
+
+def get_unet_output_block_index_range():
+    return 12
+
+def evaluate_unet_output_block_index(unet_idx):
+    return unet_idx % 3 == 2 and unet_idx != 11
+
+def is_unet_middle_block_injected(unet):
+    return len(unet.middle_block) > 3 # SD1.5 UNet has 3 expected middle_blocks - more means injected
 
 def inject_motion_module_to_unet(unet, motion_module: MotionWrapper, injection_params: InjectionParams):
     logger_animatediff.info(f"Injecting motion module into UNet input blocks.")
-    for mm_idx, unet_idx in enumerate([1, 2, 4, 5, 7, 8, 10, 11]):
+    for mm_idx, unet_idx in enumerate(get_unet_input_block_indices()):
         mm_idx0, mm_idx1 = mm_idx // 2, mm_idx % 2
         unet.input_blocks[unet_idx].append(
             motion_module.down_blocks[mm_idx0].motion_modules[mm_idx1]
         )
 
     logger_animatediff.info(f"Injecting motion module into UNet output blocks.")
-    for unet_idx in range(12):
+    for unet_idx in range(get_unet_output_block_index_range()):
         mm_idx0, mm_idx1 = unet_idx // 3, unet_idx % 3
-        if unet_idx % 3 == 2 and unet_idx != 11:
+        if evaluate_unet_output_block_index(unet_idx):
             unet.output_blocks[unet_idx].insert(
                 -1, motion_module.up_blocks[mm_idx0].motion_modules[mm_idx1]
             )
@@ -102,18 +121,53 @@ def inject_motion_module_to_unet(unet, motion_module: MotionWrapper, injection_p
 
 def eject_motion_module_from_unet(unet):
     logger_animatediff.info(f"Ejecting motion module from UNet input blocks.")
-    for unet_idx in [1, 2, 4, 5, 7, 8, 10, 11]:
+    for unet_idx in get_unet_input_block_indices():
         unet.input_blocks[unet_idx].pop(-1)
 
     logger_animatediff.info(f"Ejecting motion module from UNet output blocks.")
-    for unet_idx in range(12):
-        if unet_idx % 3 == 2 and unet_idx != 11:
+    for unet_idx in range(get_unet_output_block_index_range()):
+        if evaluate_unet_output_block_index(unet_idx):
             unet.output_blocks[unet_idx].pop(-2)
         else:
             unet.output_blocks[unet_idx].pop(-1)
     
-    if len(unet.middle_block) > 3: # SD1.5 UNet has 3 expected middle_blocks - more means injected
+    if is_unet_middle_block_injected(unet):
         logger_animatediff.info(f"Ejecting motion module from UNet middle blocks.")
         unet.middle_block.pop(-2)
     delattr(unet, MM_INJECTED_ATTR)
+    
+def set_ddim_alpha(p, betas, alphas_cumprod, alphas_cumprod_prev):
+    p.sd_model.betas = betas
+    p.sd_model.alphas_cumprod = alphas_cumprod
+    p.sd_model.alphas_cumprod_prev = alphas_cumprod_prev
+    
+def set_ddim_alpha_for_animatediff(p):
+    global ORIGINAL_DDIM_BETAS
+    logger_animatediff.info(f"Setting DDIM alpha for AnimateDiff compatibility.")
+    beta_start = 0.00085
+    beta_end = 0.012
+    betas = torch.linspace(beta_start, beta_end, p.sd_model.num_timesteps, dtype=torch.float32, device=device)
+    alphas = 1.0 - betas
+    alphas_cumprod = torch.cumprod(alphas, dim=0)
+    alphas_cumprod_prev = torch.cat(
+        (torch.tensor([1.0], dtype=torch.float32, device=device), alphas_cumprod[:-1]))
+    
+    # Backup original DDIM data
+    ORIGINAL_DDIM_BETAS = {
+        "betas": p.sd_model.betas, "alphas_cumprod": p.sd_model.alphas_cumprod, "alphas_cumprod_prev": p.sd_model.alphas_cumprod_prev 
+        }
+    
+    set_ddim_alpha(p, betas, alphas_cumprod, alphas_cumprod_prev)
+    
+def restore_original_ddim_alpha(p):
+    global ORIGINAL_DDIM_BETAS
+    assert len(ORIGINAL_DDIM_BETAS.items()) > 0 and "betas" in ORIGINAL_DDIM_BETAS and "alphas_cumprod" in ORIGINAL_DDIM_BETAS and "alphas_cumprod_prev" in ORIGINAL_DDIM_BETAS
+    logger_animatediff.info(f"Restoring original DDIM alpha.")
+    
+    set_ddim_alpha(p, 
+        ORIGINAL_DDIM_BETAS["betas"], 
+        ORIGINAL_DDIM_BETAS["alphas_cumprod"], 
+        ORIGINAL_DDIM_BETAS["alphas_cumprod_prev"])
+    
+    ORIGINAL_DDIM_BETAS = {}
     


### PR DESCRIPTION
motion_module:

-Use class for block type
-Get max video length from the state dict instead of hardcoded
-Infer version of mm from mid_block presence
-Add API access to set video length
-Adjust spacing for readability

animatediff:
-Moved settings and injection-related code to separate scripts
-Renamed some functions and buttons to reflect their behaviour
-Refactored some code out into separate functions for readability and reusability
-Separated some UI elements' title text into 'info' text for the sake of serialization ("FPS" serializes more succinctly than "Frames per second (FPS)")
-Serialize UI controls to p.extra_generation_params (for infotext meta embedding)
-Only load the mm into memory if it doesn't exist or has changed
-Fix infotext under video after generation only showing main prompt (so wildcards used to display unparsed, this shows the parsed wildcard text instead)
-Add generation infotext to gif comment and webp exif meta fields (so generation parameters can be saved, can be disabled with shared.opts.enable_pnginfo)
-Fix duration bug (setting FPS used to do seemingly nothing because the number was too small for the parameter, now it works as expected)
-Add implementation code for custom paths, filename and subdirectory patterns, webp support, quality options, and other things defined in settings_animatediff
-Add support for pasting animatediff UI parameters from infotext

settings_animatediff:
-Separated settings into its own script file
-Add option to choose whether to save videos
-Add support for webp format (better color at a smaller filesize)
-Add a lossless quality option (within reason for the file format, gif will never look perfect)
-Add video quality slider for webp (file size vs image quality)
-Add configurable filename pattern for saved videos
-Add option to specify output directory
-Add option for automatic subdirectory
-Add configurable subdirectory name pattern
-Add option to paste accordion settings from infotext meta saved to videos (for ex, model name, fps, etc)

unet_injection:
-Separated injection and ejection code to another script
-Add functions to hack and restore groupnorm
-Add options to hack and restore Timestep
-Added helper functions to keep data consistent for injection and ejection (i.e. get_unet_input_block_indices() and others)
-Add function to restore DDIM alpha after ejection