### PR TITLE
[TESTING] Support for vlad's fork.

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -38,6 +38,7 @@ class ToolButton(gr.Button, gr.components.FormComponent):
     def get_block_name(self):
         return "button"
 
+fseries = lambda vfrom, vcnt: list(range(vfrom, vfrom + vcnt))
 
 class AnimateDiffScript(scripts.Script):
     motion_module: MotionWrapper = None

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -206,7 +206,7 @@ class AnimateDiffScript(scripts.Script):
         self.prev_alpha_cumprod = None
         self.prev_alpha_cumprod_prev = None
 
-    def before_process(self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v15.ckpt"):
+    def process(self, p: StableDiffusionProcessing, enable_animatediff=False, loop_number=0, video_length=16, fps=8, model="mm_sd_v15.ckpt", **kwargs):
         if enable_animatediff:
             self.logger.info(f"AnimateDiff process start with video Max frames {video_length}, FPS {fps}, duration {video_length/fps},  motion module {model}.")
             assert video_length > 0 and fps > 0, "Video length and FPS should be positive."


### PR DESCRIPTION
Addresses #13, #18, #57.

The most obvious reason vlad's fork is breaking is because it has removed the before_process callback a long while back (or maybe never added it, I'm not sure, my old versions of auto's from march aren't showing it either). Therefore the motion module never gets inited beyond null. There's an unguarded check during remove_motion_modules `if AnimateDiffScript.motion_module.using_v2:` which leaves the cleanup in an unexpected state and the rest of the runs get messed up worse.
The earliest available callback besides that is `process`, and it doesn't seem to be all too different (a couple overrides doing nothing for me in process_images, seed, apply_circular + clear_comments, prompt alls and loading embeddings optionally in process_images_inner). Having changed that, I still needed to change the batchsize (not count) manually, otherwise it only gives out a single image filled with noise. This can probably be done during process call too. Kindly ensure the callback is suitable in the other repos as well.

Having reviewed some parts of the code, I'd also like to mention that there are a handful of bad practices, like the aforementioned cleanup crash which should not have happened so ungracefully, checking a handful of model hashes instead of structure to set using_v2, and TimestepEmbedSequential.forward getting overridden **before the extension has been enabled by the user** and doesn't get restored. Do with it what you will, but such practices tend to cause heisenbugs and repeating issues on the repo (or even for others in the case of automatic self activation) down the line in my experience.

Here's a sample run.
![00012-3907245505](https://github.com/continue-revolution/sd-webui-animatediff/assets/41131377/664a596c-4287-4e39-9241-2188777dd787)