### PR TITLE
[Refactor + bugfix] Default setting values fix.

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -247,9 +247,9 @@ fseti = lambda x: shared.opts.data.get(EXTKEY + "_" + x, DEXTSETV[x])
 
 def on_ui_settings():
     section = (EXTKEY, EXTNAME)
-    shared.opts.add_option("animatediff_model_path", shared.OptionInfo(os.path.join(script_dir, "model"), "Path to save AnimateDiff motion modules", gr.Textbox, section=section))
-    shared.opts.add_option("animatediff_hack_gn", shared.OptionInfo(
-        True, "Check if you want to hack GroupNorm. By default, V1 hacks GroupNorm, which avoids a performance degradation. "
+    shared.opts.add_option("animatediff_model_path", shared.OptionInfo(DEXTSETV["model_path"], "Path to save AnimateDiff motion modules", gr.Textbox, section=section))
+    shared.opts.add_option("animatediff_hack_gn", shared.OptionInfo(DEXTSETV["hack_gn"],
+        "Check if you want to hack GroupNorm. By default, V1 hacks GroupNorm, which avoids a performance degradation. "
         "If you choose not to hack GroupNorm for V1, you will be able to use this extension in img2img in all cases, but the generated GIF will have flickers. "
         "V2 does not hack GroupNorm, so that this option will not influence v2 inference.", gr.Checkbox, section=section))
 


### PR DESCRIPTION
This is a fix and future proofing for default setting values.

When an extension is installed, webui does not automatically add its settings to the ini file. Instead, the addition is deferred to the first save (hence why many settings are shown as changed the first time), and till then the code gets a null value from shared.opts. The default in hack_gn is false unlike its setting default, therefore running before the first save will yield an unexpected flickering result in spite of the setting.
The DEXTSETV dict + fseti function circumvent that, defaults are added to a single location which is accessed both in setting creation and all gets. Plus less copypasta.