### PR TITLE
Add GIF palette optimization

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -63,6 +63,15 @@ def on_ui_settings():
             section=section,
         ),
     )
+    shared.opts.add_option(
+        "animatediff_optimize_gif_palette",
+        shared.OptionInfo(
+            False,
+            "Calculate the optimal GIF palette, improves quality significantly, removes banding",
+            gr.Checkbox,
+            section=section
+        )
+    )
 
 
 script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -1,7 +1,8 @@
-import imageio
+import imageio.v3 as imageio
 from pathlib import Path
+import numpy as np
 
-from modules import images
+from modules import images, shared
 from modules.processing import StableDiffusionProcessing, Processed
 
 from scripts.animatediff_logger import logger_animatediff as logger
@@ -48,21 +49,52 @@ class AnimateDiffOutput:
         index: int,
     ):
         video_paths = []
+        video_array = [np.array(v) for v in video_list]
         if "GIF" in params.format:
             video_path_gif = video_path_prefix + "gif"
             video_paths.append(video_path_gif)
-            imageio.mimsave(
-                video_path_gif,
-                video_list,
-                duration=(1 / params.fps),
-                loop=params.loop_number,
-            )
+            if shared.opts.data.get("animatediff_optimize_gif_palette", True):
+                try:
+                    import av
+                except ImportError:
+                    from launch import run_pip
+                    run_pip(
+                        "install imageio[pyav]",
+                        "sd-webui-animatediff GIF palette optimization requirement: imageio[pyav]",
+                    )
+                imageio.imwrite(
+                    video_path_gif, video_array, plugin='pyav', fps=params.fps, 
+                    codec='gif', out_pixel_format='pal8',
+                    filter_graph=(
+                        {
+                            "split": ("split", ""),
+                            "palgen": ("palettegen", ""),
+                            "paluse": ("paletteuse", ""),
+                            "scale": ("scale", f"{video_list[0].width}:{video_list[0].height}")
+                        },
+                        [
+                            ("video_in", "scale", 0, 0),
+                            ("scale", "split", 0, 0),
+                            ("split", "palgen", 1, 0),
+                            ("split", "paluse", 0, 0),
+                            ("palgen", "paluse", 0, 1),
+                            ("paluse", "video_out", 0, 0),
+                        ]
+                    )
+                )
+            else:
+                imageio.imwrite(
+                    video_path_gif,
+                    video_array,
+                    duration=(1000 / params.fps),
+                    loop=params.loop_number,
+                )
             if "Optimize GIF" in params.format:
                 self._optimize_gif(video_path_gif)
         if "MP4" in params.format:
             video_path_mp4 = video_path_prefix + "mp4"
             video_paths.append(video_path_mp4)
-            imageio.mimsave(video_path_mp4, video_list, fps=params.fps)
+            imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
         if "TXT" in params.format and res.images[index].info is not None:
             video_path_txt = video_path_prefix + "txt"
             self._save_txt(params, video_path_txt, res, index)


### PR DESCRIPTION
The default GIF saving algorithm lacks dithering and palette optimization which results in noticeable banding artifacts. In this PR I add a new option (turned off by default) that enables these features. The new imageio v3 API is used for that because it supports pyav plugin which creates the resulting GIF with `ffmpeg` and a filter graph that precalculates the palette from all frames in the sequence. If the `av` library is missing it installs it automatically. As a result, the GIF looks much better but the file might be bigger (not always), and it also requires a dependency to install.

There's a weird quirk that I couldn't explain. If the filter graph is used, the image is always resized to `640x480` no matter what its source size is. It's probably a bug somewhere in the pyav plugin or the av library because ffmpeg with the same graph doesn't do that. So to mitigate it I added a scale filter to the graph in the beginning.

### Comparison

| Palette | Size | Image |
|--------|--------|--------|
| No optimization | 3.8 Mb | ![02078-3855594682](https://github.com/continue-revolution/sd-webui-animatediff/assets/184066/4f5e9134-0314-4b18-882d-10487d160687)|
| Optimized | 4.5 Mb | ![02077-3855594682_opt](https://github.com/continue-revolution/sd-webui-animatediff/assets/184066/2dd30019-85b5-4c38-bd03-43b7b2de42d0) | 

Banding is visible on the ground in the first GIF, it's even worse in dynamic.

Note that these images are not perfectly in sync. Turns out the Pillow GIF creator is a bit less smart than ffmpeg. The default 8 FPS setting means that every frame should be shown for 125 ms (1000/8), however, the GIF spec says that the frame time is specified in hundredths of a second which would be 12.5. Since 0.5 can't be represented, Pillow uses just 12 which gives us 8.(3) FPS instead of 8.

Ffmpeg does an interesting trick, it alternates the frame delays between 130 and 120 ms which, on average, gives us 125 ms and 8 FPS. So the optimized version is technically more correct in that regard too.