### PR TITLE
convert params dict to AnimateDiffProcess for API calls

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -32,6 +32,7 @@ class AnimateDiffScript(scripts.Script):
         return (AnimateDiffUiGroup().render(is_img2img, model_dir),)
 
     def before_process(self, p: StableDiffusionProcessing, params: AnimateDiffProcess):
+        if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable:
             logger.info("AnimateDiff process start.")
             params.set_p(p)
@@ -40,12 +41,14 @@ class AnimateDiffScript(scripts.Script):
     def before_process_batch(
         self, p: StableDiffusionProcessing, params: AnimateDiffProcess, **kwargs
     ):
+        if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable and isinstance(p, StableDiffusionProcessingImg2Img):
             AnimateDiffI2VLatent().randomize(p, params)
 
     def postprocess(
         self, p: StableDiffusionProcessing, res: Processed, params: AnimateDiffProcess
     ):
+        if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable:
             motion_module.restore(p.sd_model)
             AnimateDiffOutput().output(p, res, params)


### PR DESCRIPTION
Fixes initial error in issue #99. API users will still need to make the following change, and I haven't confirmed the output returned by the API call is correct yet.
```diff
diff --git a/scripts/animatediff_output.py b/scripts/animatediff_output.py
index 7b23f3a..5aa88ff 100644
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -26,8 +26,8 @@ class AnimateDiffOutput:
 
             video_list = self._add_reverse(params, video_list)
             video_paths += self._save(params, video_list, video_path_prefix, res, i)
-        if len(video_paths) > 0:
-            res.images = video_paths
+        # if len(video_paths) > 0:
+        #     res.images = video_paths
 
     def _add_reverse(self, params: AnimateDiffProcess, video_list: list):
         if 0 in params.reverse:
```
