### PR TITLE
keep res.images if called by api

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -27,7 +27,7 @@ class AnimateDiffOutput:
 
             video_list = self._add_reverse(params, video_list)
             video_paths += self._save(params, video_list, video_path_prefix, res, i)
-        if len(video_paths) > 0:
+        if len(video_paths) > 0 and not p.is_api:
             res.images = video_paths
 
     def _add_reverse(self, params: AnimateDiffProcess, video_list: list):


### PR DESCRIPTION
This fixes api calls while keeping the regular UI working the same as before.

I can confirm that the API call returns a list of images, and the images are the frames of the animation. The GIF was also saved to the usual location.

PS - I discovered that API calls can be tested by running with --api (obviously) and going to http://localhost:7860/docs for the API docs. Find txt2img, expand it and look in the upper-right corner for a button named Try it out. This lets you paste in a properly formatted json and download the response. The images can be decoded with base64 -d -i file > output.png