### PR TITLE
Add Tooltips and Element ID's

### DIFF
--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -98,7 +98,7 @@ class AnimateDiffUiGroup:
     def render(self, is_img2img: bool, model_dir: str):
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
-        element_id_prefix = "ad-img2img-" if is_img2img else "ad-"
+        elemid_prefix = "img2img-ad-" if is_img2img else "txt2img-ad-"
         model_list = [f for f in os.listdir(model_dir) if f != ".gitkeep"]
         with gr.Accordion("AnimateDiff", open=False):
             with gr.Row():
@@ -122,7 +122,7 @@ class AnimateDiffUiGroup:
                     label="Motion module",
                     type="value",
                     tooltip="Choose which motion module will be injected into the generation process.",
-                    elem_id=element_id_prefix + "motion-module",
+                    elem_id=f"{elemid_prefix}motion-module",
                 )
                 refresh_model = ToolButton(value="\U0001f504")
                 refresh_model.click(
@@ -130,7 +130,8 @@ class AnimateDiffUiGroup:
                 )
             with gr.Row():
                 self.params.enable = gr.Checkbox(
-                    value=self.params.enable, label="Enable AnimateDiff", elem_id=element_id_prefix + "enable"
+                    value=self.params.enable, label="Enable AnimateDiff", 
+                    elem_id=f"{elemid_prefix}enable"
                 )
                 self.params.video_length = gr.Number(
                     minimum=0,
@@ -138,10 +139,12 @@ class AnimateDiffUiGroup:
                     label="Number of frames",
                     precision=0,
                     tooltip="Total length of video in frames.",
-                    elem_id=element_id_prefix + "video-length",
+                    elem_id=f"{elemid_prefix}video-length",
                 )
                 self.params.fps = gr.Number(
-                    value=self.params.fps, label="FPS", precision=0, tooltip="How many frames per second the gif will run.", elem_id=element_id_prefix + "fps"
+                    value=self.params.fps, label="FPS", precision=0, 
+                    tooltip="How many frames per second the gif will run.", 
+                    elem_id=f"{elemid_prefix}fps"
                 )
                 self.params.loop_number = gr.Number(
                     minimum=0,
@@ -149,14 +152,14 @@ class AnimateDiffUiGroup:
                     label="Display loop number",
                     precision=0,
                     tooltip="How many times the animation will loop, a value of 0 will loop forever.",
-                    elem_id=element_id_prefix + "loop-number",
+                    elem_id=f"{elemid_prefix}loop-number",
                 )
             with gr.Row():
                 self.params.closed_loop = gr.Checkbox(
                     value=self.params.closed_loop,
                     label="Closed loop",
                     tooltip="If enabled, will try to make the last frame the same as the first frame.",
-                    elem_id=element_id_prefix + "closed-loop",
+                    elem_id=f"{elemid_prefix}closed-loop",
                 )
                 self.params.batch_size = gr.Slider(
                     minimum=1,
@@ -165,7 +168,7 @@ class AnimateDiffUiGroup:
                     label="Context batch size",
                     step=1,
                     precision=0,
-                    elem_id=element_id_prefix + "batch-size",
+                    elem_id=f"{elemid_prefix}batch-size",
                 )
                 self.params.stride = gr.Number(
                     minimum=1,
@@ -173,7 +176,7 @@ class AnimateDiffUiGroup:
                     label="Stride",
                     precision=0,
                     tooltip="",
-                    elem_id=element_id_prefix + "stride",
+                    elem_id=f"{elemid_prefix}stride",
                 )
                 self.params.overlap = gr.Number(
                     minimum=-1,
@@ -181,7 +184,7 @@ class AnimateDiffUiGroup:
                     label="Overlap",
                     precision=0,
                     tooltip="Number of frames to overlap in context.",
-                    elem_id=element_id_prefix + "overlap",
+                    elem_id=f"{elemid_prefix}overlap",
                 )
             with gr.Row():
                 self.params.format = gr.CheckboxGroup(
@@ -189,7 +192,7 @@ class AnimateDiffUiGroup:
                     label="Save",
                     type="value",
                     tooltip="Which formats the animation should be saved in",
-                    elem_id=element_id_prefix + "save-format",
+                    elem_id=f"{elemid_prefix}save-format",
                     value=self.params.format,
                 )
                 self.params.reverse = gr.CheckboxGroup(
@@ -197,7 +200,7 @@ class AnimateDiffUiGroup:
                     label="Reverse",
                     type="index",
                     tooltip="Reverse the resulting animation, remove the first and/or last frame from duplication.",
-                    elem_id=element_id_prefix + "reverse",
+                    elem_id=f"{elemid_prefix}reverse",
                     value=self.params.reverse
                 )
             with gr.Row():
@@ -205,11 +208,13 @@ class AnimateDiffUiGroup:
                     choices=["Off", "FILM"],
                     label="Frame Interpolation",
                     tooltip="Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.",
-                    elem_id=element_id_prefix + "interp-choice",
+                    elem_id=f"{elemid_prefix}interp-choice",
                     value=self.params.interp
                 )
                 self.params.interp_x = gr.Number(
-                    value=self.params.interp_x, label="Interp X", precision=0, tooltip="Replace each input frame with X interpolated output frames.", elem_id=element_id_prefix + "interp-x"
+                    value=self.params.interp_x, label="Interp X", precision=0, 
+                    tooltip="Replace each input frame with X interpolated output frames.", 
+                    elem_id=f"{elemid_prefix}interp-x"
                 )
             self.params.video_source = gr.Video(
                 value=self.params.video_source,
@@ -219,7 +224,7 @@ class AnimateDiffUiGroup:
                 value=self.params.video_path,
                 label="Video path",
                 tooltip="Paste path to video file.",
-                elem_id=element_id_prefix + "video-path"
+                elem_id=f"{elemid_prefix}video-path"
             )
             if is_img2img:
                 with gr.Row():
@@ -230,7 +235,7 @@ class AnimateDiffUiGroup:
                         step=0.1,
                         label="Latent power",
                         tooltip="",
-                        elem_id=element_id_prefix + "latent-power",
+                        elem_id=f"{elemid_prefix}latent-power",
                     )
                     self.params.latent_scale = gr.Slider(
                         minimum=1,
@@ -238,7 +243,7 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_scale,
                         label="Latent scale",
                         tooltip="",
-                        elem_id=element_id_prefix + "latent-scale"
+                        elem_id=f"{elemid_prefix}latent-scale"
                     )
                     self.params.latent_power_last = gr.Slider(
                         minimum=0.1,
@@ -247,7 +252,7 @@ class AnimateDiffUiGroup:
                         step=0.1,
                         label="Optional latent power for last frame",
                         tooltip="",
-                        elem_id=element_id_prefix + "latent-power-last",
+                        elem_id=f"{elemid_prefix}latent-power-last",
                     )
                     self.params.latent_scale_last = gr.Slider(
                         minimum=1,
@@ -255,7 +260,7 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_scale_last,
                         label="Optional latent scale for last frame",
                         tooltip="",
-                        elem_id=element_id_prefix + "latent-scale-last"
+                        elem_id=f"{elemid_prefix}latent-scale-last"
                     )
                 self.params.last_frame = gr.Image(
                     label="[Experiment] Optional last frame. Leave it blank if you do not need one.",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -98,6 +98,7 @@ class AnimateDiffUiGroup:
     def render(self, is_img2img: bool, model_dir: str):
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
+        element_id_prefix = "ad-img2img-" if is_img2img else "ad-"
         model_list = [f for f in os.listdir(model_dir) if f != ".gitkeep"]
         with gr.Accordion("AnimateDiff", open=False):
             with gr.Row():
@@ -121,7 +122,7 @@ class AnimateDiffUiGroup:
                     label="Motion module",
                     type="value",
                     tooltip="Choose which motion module will be injected into the generation process.",
-                    elem_id="ad-motion-module",
+                    elem_id=element_id_prefix + "motion-module",
                 )
                 refresh_model = ToolButton(value="\U0001f504")
                 refresh_model.click(
@@ -129,7 +130,7 @@ class AnimateDiffUiGroup:
                 )
             with gr.Row():
                 self.params.enable = gr.Checkbox(
-                    value=self.params.enable, label="Enable AnimateDiff", elem_id="ad-enable"
+                    value=self.params.enable, label="Enable AnimateDiff", elem_id=element_id_prefix + "enable"
                 )
                 self.params.video_length = gr.Number(
                     minimum=0,
@@ -137,10 +138,10 @@ class AnimateDiffUiGroup:
                     label="Number of frames",
                     precision=0,
                     tooltip="Total length of video in frames.",
-                    elem_id="ad-video-length",
+                    elem_id=element_id_prefix + "video-length",
                 )
                 self.params.fps = gr.Number(
-                    value=self.params.fps, label="FPS", precision=0, tooltip="How many frames per second the gif will run.", elem_id="ad-fps"
+                    value=self.params.fps, label="FPS", precision=0, tooltip="How many frames per second the gif will run.", elem_id=element_id_prefix + "fps"
                 )
                 self.params.loop_number = gr.Number(
                     minimum=0,
@@ -148,14 +149,14 @@ class AnimateDiffUiGroup:
                     label="Display loop number",
                     precision=0,
                     tooltip="How many times the animation will loop, a value of 0 will loop forever.",
-                    elem_id="ad-loop-number",
+                    elem_id=element_id_prefix + "loop-number",
                 )
             with gr.Row():
                 self.params.closed_loop = gr.Checkbox(
                     value=self.params.closed_loop,
                     label="Closed loop",
                     tooltip="If enabled, will try to make the last frame the same as the first frame.",
-                    elem_id="ad-closed-loop",
+                    elem_id=element_id_prefix + "closed-loop",
                 )
                 self.params.batch_size = gr.Slider(
                     minimum=1,
@@ -164,7 +165,7 @@ class AnimateDiffUiGroup:
                     label="Context batch size",
                     step=1,
                     precision=0,
-                    elem_id="ad-batch-size",
+                    elem_id=element_id_prefix + "batch-size",
                 )
                 self.params.stride = gr.Number(
                     minimum=1,
@@ -172,7 +173,7 @@ class AnimateDiffUiGroup:
                     label="Stride",
                     precision=0,
                     tooltip="",
-                    elem_id="ad-stride",
+                    elem_id=element_id_prefix + "stride",
                 )
                 self.params.overlap = gr.Number(
                     minimum=-1,
@@ -180,7 +181,7 @@ class AnimateDiffUiGroup:
                     label="Overlap",
                     precision=0,
                     tooltip="Number of frames to overlap in context.",
-                    elem_id="ad-overlap",
+                    elem_id=element_id_prefix + "overlap",
                 )
             with gr.Row():
                 self.params.format = gr.CheckboxGroup(
@@ -188,7 +189,7 @@ class AnimateDiffUiGroup:
                     label="Save",
                     type="value",
                     tooltip="Which formats the animation should be saved in",
-                    elem_id="ad-save-format",
+                    elem_id=element_id_prefix + "save-format",
                     value=self.params.format,
                 )
                 self.params.reverse = gr.CheckboxGroup(
@@ -196,7 +197,7 @@ class AnimateDiffUiGroup:
                     label="Reverse",
                     type="index",
                     tooltip="Reverse the resulting animation, remove the first and/or last frame from duplication.",
-                    elem_id="ad-reverse",
+                    elem_id=element_id_prefix + "reverse",
                     value=self.params.reverse
                 )
             with gr.Row():
@@ -204,11 +205,11 @@ class AnimateDiffUiGroup:
                     choices=["Off", "FILM"],
                     label="Frame Interpolation",
                     tooltip="Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.",
-                    elem_id="ad-interp-choice",
+                    elem_id=element_id_prefix + "interp-choice",
                     value=self.params.interp
                 )
                 self.params.interp_x = gr.Number(
-                    value=self.params.interp_x, label="Interp X", precision=0, tooltip="Replace each input frame with X interpolated output frames.", elem_id="ad-interp-x"
+                    value=self.params.interp_x, label="Interp X", precision=0, tooltip="Replace each input frame with X interpolated output frames.", elem_id=element_id_prefix + "interp-x"
                 )
             self.params.video_source = gr.Video(
                 value=self.params.video_source,
@@ -218,7 +219,7 @@ class AnimateDiffUiGroup:
                 value=self.params.video_path,
                 label="Video path",
                 tooltip="Paste path to video file.",
-                elem_id="ad-video-path"
+                elem_id=element_id_prefix + "video-path"
             )
             if is_img2img:
                 with gr.Row():
@@ -229,7 +230,7 @@ class AnimateDiffUiGroup:
                         step=0.1,
                         label="Latent power",
                         tooltip="",
-                        elem_id="ad-latent-power",
+                        elem_id=element_id_prefix + "latent-power",
                     )
                     self.params.latent_scale = gr.Slider(
                         minimum=1,
@@ -237,7 +238,7 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_scale,
                         label="Latent scale",
                         tooltip="",
-                        elem_id="ad-latent-scale"
+                        elem_id=element_id_prefix + "latent-scale"
                     )
                     self.params.latent_power_last = gr.Slider(
                         minimum=0.1,
@@ -246,7 +247,7 @@ class AnimateDiffUiGroup:
                         step=0.1,
                         label="Optional latent power for last frame",
                         tooltip="",
-                        elem_id="ad-latent-power-last",
+                        elem_id=element_id_prefix + "latent-power-last",
                     )
                     self.params.latent_scale_last = gr.Slider(
                         minimum=1,
@@ -254,7 +255,7 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_scale_last,
                         label="Optional latent scale for last frame",
                         tooltip="",
-                        elem_id="ad-latent-scale-last"
+                        elem_id=element_id_prefix + "latent-scale-last"
                     )
                 self.params.last_frame = gr.Image(
                     label="[Experiment] Optional last frame. Leave it blank if you do not need one.",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -120,6 +120,8 @@ class AnimateDiffUiGroup:
                     value=(self.params.model if self.params.model in model_list else None),
                     label="Motion module",
                     type="value",
+                    tooltip="Choose which motion module will be injected into the generation process.",
+                    elem_id="ad-motion-module",
                 )
                 refresh_model = ToolButton(value="\U0001f504")
                 refresh_model.click(
@@ -127,27 +129,33 @@ class AnimateDiffUiGroup:
                 )
             with gr.Row():
                 self.params.enable = gr.Checkbox(
-                    value=self.params.enable, label="Enable AnimateDiff"
+                    value=self.params.enable, label="Enable AnimateDiff", elem_id="ad-enable"
                 )
                 self.params.video_length = gr.Number(
                     minimum=0,
                     value=self.params.video_length,
                     label="Number of frames",
                     precision=0,
+                    tooltip="Total length of video in frames.",
+                    elem_id="ad-video-length",
                 )
                 self.params.fps = gr.Number(
-                    value=self.params.fps, label="FPS", precision=0
+                    value=self.params.fps, label="FPS", precision=0, tooltip="How many frames per second the gif will run.", elem_id="ad-fps"
                 )
                 self.params.loop_number = gr.Number(
                     minimum=0,
                     value=self.params.loop_number,
                     label="Display loop number",
                     precision=0,
+                    tooltip="How many times the animation will loop, a value of 0 will loop forever.",
+                    elem_id="ad-loop-number",
                 )
             with gr.Row():
                 self.params.closed_loop = gr.Checkbox(
                     value=self.params.closed_loop,
                     label="Closed loop",
+                    tooltip="If enabled, will try to make the last frame the same as the first frame.",
+                    elem_id="ad-closed-loop",
                 )
                 self.params.batch_size = gr.Slider(
                     minimum=1,
@@ -156,40 +164,51 @@ class AnimateDiffUiGroup:
                     label="Context batch size",
                     step=1,
                     precision=0,
+                    elem_id="ad-batch-size",
                 )
                 self.params.stride = gr.Number(
                     minimum=1,
                     value=self.params.stride,
                     label="Stride",
                     precision=0,
+                    tooltip="",
+                    elem_id="ad-stride",
                 )
                 self.params.overlap = gr.Number(
                     minimum=-1,
                     value=self.params.overlap,
                     label="Overlap",
                     precision=0,
+                    tooltip="Number of frames to overlap in context.",
+                    elem_id="ad-overlap",
                 )
             with gr.Row():
                 self.params.format = gr.CheckboxGroup(
                     choices=["GIF", "MP4", "PNG", "TXT"],
                     label="Save",
                     type="value",
+                    tooltip="Which formats the animation should be saved in",
+                    elem_id="ad-save-format",
                     value=self.params.format,
                 )
                 self.params.reverse = gr.CheckboxGroup(
                     choices=["Add Reverse Frame", "Remove head", "Remove tail"],
                     label="Reverse",
                     type="index",
+                    tooltip="Reverse the resulting animation, remove the first and/or last frame from duplication.",
+                    elem_id="ad-reverse",
                     value=self.params.reverse
                 )
             with gr.Row():
                 self.params.interp = gr.Radio(
                     choices=["Off", "FILM"],
                     label="Frame Interpolation",
+                    tooltip="Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.",
+                    elem_id="ad-interp-choice",
                     value=self.params.interp
                 )
                 self.params.interp_x = gr.Number(
-                    value=self.params.interp_x, label="Interp X", precision=0
+                    value=self.params.interp_x, label="Interp X", precision=0, tooltip="Replace each input frame with X interpolated output frames.", elem_id="ad-interp-x"
                 )
             self.params.video_source = gr.Video(
                 value=self.params.video_source,
@@ -198,6 +217,8 @@ class AnimateDiffUiGroup:
             self.params.video_path = gr.Textbox(
                 value=self.params.video_path,
                 label="Video path",
+                tooltip="Paste path to video file.",
+                elem_id="ad-video-path"
             )
             if is_img2img:
                 with gr.Row():
@@ -207,12 +228,16 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_power,
                         step=0.1,
                         label="Latent power",
+                        tooltip="",
+                        elem_id="ad-latent-power",
                     )
                     self.params.latent_scale = gr.Slider(
                         minimum=1,
                         maximum=128,
                         value=self.params.latent_scale,
                         label="Latent scale",
+                        tooltip="",
+                        elem_id="ad-latent-scale"
                     )
                     self.params.latent_power_last = gr.Slider(
                         minimum=0.1,
@@ -220,12 +245,16 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_power_last,
                         step=0.1,
                         label="Optional latent power for last frame",
+                        tooltip="",
+                        elem_id="ad-latent-power-last",
                     )
                     self.params.latent_scale_last = gr.Slider(
                         minimum=1,
                         maximum=128,
                         value=self.params.latent_scale_last,
                         label="Optional latent scale for last frame",
+                        tooltip="",
+                        elem_id="ad-latent-scale-last"
                     )
                 self.params.last_frame = gr.Image(
                     label="[Experiment] Optional last frame. Leave it blank if you do not need one.",


### PR DESCRIPTION
I added tooltips to each relevant location in webui, to help explain each feature without needing to open the github page. I did not know what to put in the tooltip for stride, or the options in img2img so I left those blank for you to fill out if you're interested.

I also added element id's so that extensions like Config-Presets can latch on and control each configurable option.