### PR TITLE
improve file handling

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -102,7 +102,11 @@ class AnimateDiffOutput:
 
         # load deforum output frames and replace video_list
         interp_frame_paths = sorted(glob.glob(os.path.join(save_folder, '*.png')))
-        video_list = [Image.open(f) for f in interp_frame_paths]
+        video_list = []
+        for f in interp_frame_paths:
+            with Image.open(f) as img:
+                img.load()
+                video_list.append(img)
         
         # if saving PNG, also save interpolated frames
         if "PNG" in params.format:


### PR DESCRIPTION
Image.open() in _interp may be holding files open. Docs recommend using .load() this way and it should close the file if it has a single frame. This may resolve #145 