### PR TITLE
Bug, move video source fps detection to ui

### DIFF
--- a/scripts/animatediff_cn.py
+++ b/scripts/animatediff_cn.py
@@ -34,7 +34,6 @@ class AnimateDiffControl:
         def get_input_frames():
             if params.video_source is not None and params.video_source != '':
                 cap = cv2.VideoCapture(params.video_source)
-                params.fps = int(cap.get(cv2.CAP_PROP_FPS))
                 frame_count = 0
                 tmp_frame_dir = Path(f'{data_path}/tmp/animatediff-frames/')
                 tmp_frame_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -230,7 +230,6 @@ class AnimateDiffUiGroup:
                 else:
                     return self.params.fps
             self.params.video_source.change(update_fps, inputs=self.params.video_source, outputs=self.params.fps)
-            
             self.params.video_path = gr.Textbox(
                 value=self.params.video_path,
                 label="Video path",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -1,5 +1,6 @@
 import os
 
+import cv2
 import gradio as gr
 
 from scripts.animatediff_mm import mm_animatediff as motion_module
@@ -220,6 +221,16 @@ class AnimateDiffUiGroup:
                 value=self.params.video_source,
                 label="Video source",
             )
+            def update_fps(video_source):
+                if video_source is not None and video_source != '':
+                    cap = cv2.VideoCapture(video_source)
+                    fps = int(cap.get(cv2.CAP_PROP_FPS))
+                    cap.release()
+                    return fps
+                else:
+                    return self.params.fps
+            self.params.video_source.change(update_fps, inputs=self.params.video_source, outputs=self.params.fps)
+            
             self.params.video_path = gr.Textbox(
                 value=self.params.video_path,
                 label="Video path",


### PR DESCRIPTION
When using ControlNet and a source video, the fps is set in a function called by before_process. This prevents the user from specifying an fps value other than the source video fps. It also doesn't update the UI to indicate the changed fps.

This PR moves setting the fps to the UI, using a gradio event listener. It allows the user to change fps after loading a video, and preserves the behavior of detecting and setting output fps on video load.
