### PR TITLE
Bug, error when clearing video source

### DIFF
--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -228,7 +228,7 @@ class AnimateDiffUiGroup:
                     cap.release()
                     return fps
                 else:
-                    return self.params.fps
+                    return int(self.params.fps.value)
             self.params.video_source.change(update_fps, inputs=self.params.video_source, outputs=self.params.fps)
             self.params.video_path = gr.Textbox(
                 value=self.params.video_path,


### PR DESCRIPTION
After adding and clearing a video source, the FPS shows "Error". Cast the FPS value to an integer and return it, instead of returning the Gradio Number UI element.