### PR TITLE
Feature png output folder

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -104,6 +104,15 @@ def on_ui_settings():
         )
     )
     shared.opts.add_option(
+        "animatediff_do_not_save_samples",
+        shared.OptionInfo(
+            False,
+            "Disable saving images to txt2img and img2img folders when AnimateDiff is enabled. Does not affect PNG output.",
+            gr.Checkbox,
+            section=section
+        )
+    )
+    shared.opts.add_option(
         "animatediff_xformers",
         shared.OptionInfo(
             "Optimize attention layers with xformers",

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -107,10 +107,11 @@ def on_ui_settings():
         )
     )
     shared.opts.add_option(
-        "animatediff_do_not_save_samples",
+        "animatediff_save_to_custom",
         shared.OptionInfo(
             False,
-            "Disable saving images to txt2img and img2img folders when AnimateDiff is enabled. Does not affect PNG output.",
+            "Save frames to stable-diffusion-webui/outputs/{ txt|img }2img-images/AnimateDiff/{gif filename}/ "
+            "instead of stable-diffusion-webui/outputs/{ txt|img }2img-images/{date}/.",
             gr.Checkbox,
             section=section
         )

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -24,9 +24,7 @@ class AnimateDiffOutput:
             # so make a copy instead of a slice (reference), to avoid modifying res
             video_list = [image.copy() for image in res.images[i : i + params.video_length]]
 
-            seq = images.get_next_sequence_number(
-                f"{p.outpath_samples}/AnimateDiff", ""
-            )
+            seq = images.get_next_sequence_number(f"{p.outpath_samples}/AnimateDiff", "")
             filename = f"{seq:05}-{res.seed}"
             video_path_prefix = f"{p.outpath_samples}/AnimateDiff/{filename}"
 

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import imageio.v3 as imageio
 import numpy as np
-from PIL import Image
+from PIL import Image, PngImagePlugin
 from modules import images, shared
 from modules.processing import Processed, StableDiffusionProcessing
 
@@ -131,6 +131,14 @@ class AnimateDiffOutput:
     ):
         video_paths = []
         video_array = [np.array(v) for v in video_list]
+        if "PNG" in params.format:
+            Path(video_path_prefix).mkdir(exist_ok=True, parents=True)
+            for i, frame in enumerate(video_list):
+                png_filename = f"{video_path_prefix}/{i:05}.png"
+                png_info = PngImagePlugin.PngInfo()
+                png_info.add_text('parameters', res.infotexts[0])
+                imageio.imwrite(png_filename, frame, pnginfo=png_info)
+
         if "GIF" in params.format:
             video_path_gif = video_path_prefix + ".gif"
             video_paths.append(video_path_gif)

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -34,10 +34,6 @@ class AnimateDiffOutput:
             video_list = self._interp(p, params, video_list, filename)
             video_paths += self._save(params, video_list, video_path_prefix, res, i)
 
-            # change save location for PNG frames
-            png_path = f"{p.outpath_samples}/AnimateDiff/{filename}"
-            Path(png_path).mkdir(exist_ok=True, parents=True)
-            p.outpath_samples = png_path
 
         if len(video_paths) > 0:
             if not p.is_api:

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -28,7 +28,7 @@ class AnimateDiffOutput:
                 f"{p.outpath_samples}/AnimateDiff", ""
             )
             filename = f"{seq:05}-{res.seed}"
-            video_path_prefix = f"{p.outpath_samples}/AnimateDiff/{filename}."
+            video_path_prefix = f"{p.outpath_samples}/AnimateDiff/{filename}"
 
             video_list = self._add_reverse(params, video_list)
             video_list = self._interp(p, params, video_list, filename)
@@ -132,7 +132,7 @@ class AnimateDiffOutput:
         video_paths = []
         video_array = [np.array(v) for v in video_list]
         if "GIF" in params.format:
-            video_path_gif = video_path_prefix + "gif"
+            video_path_gif = video_path_prefix + ".gif"
             video_paths.append(video_path_gif)
             if shared.opts.data.get("animatediff_optimize_gif_palette", False):
                 try:
@@ -173,11 +173,11 @@ class AnimateDiffOutput:
             if shared.opts.data.get("animatediff_optimize_gif_gifsicle", False):
                 self._optimize_gif(video_path_gif)
         if "MP4" in params.format:
-            video_path_mp4 = video_path_prefix + "mp4"
+            video_path_mp4 = video_path_prefix + ".mp4"
             video_paths.append(video_path_mp4)
             imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
         if "TXT" in params.format and res.images[index].info is not None:
-            video_path_txt = video_path_prefix + "txt"
+            video_path_txt = video_path_prefix + ".txt"
             self._save_txt(params, video_path_txt, res, index)
         return video_paths
 

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -34,6 +34,11 @@ class AnimateDiffOutput:
             video_list = self._interp(p, params, video_list, filename)
             video_paths += self._save(params, video_list, video_path_prefix, res, i)
 
+            # change save location for PNG frames
+            png_path = f"{p.outpath_samples}/AnimateDiff/{filename}"
+            Path(png_path).mkdir(exist_ok=True, parents=True)
+            p.outpath_samples = png_path
+
         if len(video_paths) > 0:
             if not p.is_api:
                 res.images = video_paths

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -130,7 +130,7 @@ class AnimateDiffOutput:
     ):
         video_paths = []
         video_array = [np.array(v) for v in video_list]
-        if "PNG" in params.format:
+        if "PNG" in params.format and shared.opts.data.get("animatediff_save_to_custom", False):
             Path(video_path_prefix).mkdir(exist_ok=True, parents=True)
             for i, frame in enumerate(video_list):
                 png_filename = f"{video_path_prefix}/{i:05}.png"

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -3,6 +3,8 @@ import os
 import cv2
 import gradio as gr
 
+from modules import shared
+
 from scripts.animatediff_mm import mm_animatediff as motion_module
 
 
@@ -93,8 +95,9 @@ class AnimateDiffProcess:
             self.video_default = False
         if self.overlap == -1:
             self.overlap = self.batch_size // 4
-        # _save will save frames to subfolders when saving PNG output
-        p.do_not_save_samples = True
+        if shared.opts.data.get("animatediff_do_not_save_samples", False):
+            # disable saving images to txt2img and img2img folders
+            p.do_not_save_samples = True
 
 
 class AnimateDiffUiGroup:

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -95,8 +95,7 @@ class AnimateDiffProcess:
             self.video_default = False
         if self.overlap == -1:
             self.overlap = self.batch_size // 4
-        if shared.opts.data.get("animatediff_do_not_save_samples", False):
-            # disable saving images to txt2img and img2img folders
+        if "PNG" not in self.format or shared.opts.data.get("animatediff_save_to_custom", False):
             p.do_not_save_samples = True
 
 

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -88,8 +88,8 @@ class AnimateDiffProcess:
             self.video_default = False
         if self.overlap == -1:
             self.overlap = self.batch_size // 4
-        if "PNG" not in self.format:
-            p.do_not_save_samples = True
+        # _save will save frames to subfolders when saving PNG output
+        p.do_not_save_samples = True
 
 
 class AnimateDiffUiGroup:


### PR DESCRIPTION
Save PNG output to separate folder under AnimateDiff. Keeps the clutter out of regular txt2img folders.
Closes #161 