### PR TITLE
1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Just like how you use ControlNet. Here is a sample. You will get a list of gener
 - `2023/09/29`: [v1.8.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.0): Infinite generation (with/without ControlNet) supported. [Demo and video instructions](#demo-and-video-instructions) are coming soon.
 - `2023/10/01`: [v1.8.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.1): Now you can uncheck `Batch cond/uncond` in `Settings/Optimization` if you want. This will reduce your VRAM (5.31GB -> 4.21GB for SDP) but take longer time.
 - `2023/10/08`: [v1.9.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.0): Prompt travel supported. You must have ControlNet installed (you do not need to enable ControlNet) to try it. See [FAQ](#faq) for how to trigger this feature.
+- `2023/10/?`: [v1.9.1](ttps://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): TODO
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Just like how you use ControlNet. Here is a sample. You will get a list of gener
 - `2023/09/29`: [v1.8.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.0): Infinite generation (with/without ControlNet) supported.
 - `2023/10/01`: [v1.8.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.1): Now you can uncheck `Batch cond/uncond` in `Settings/Optimization` if you want. This will reduce your VRAM (5.31GB -> 4.21GB for SDP) but take longer time.
 - `2023/10/08`: [v1.9.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.0): Prompt travel supported. You must have ControlNet installed (you do not need to enable ControlNet) to try it. See [FAQ](#faq) for how to trigger this feature.
-- `2023/10/?`: [v1.9.1](ttps://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): TODO
-
+- `2023/10/?`: [v1.9.1](ttps://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): Use state_dict key to guess mm version, replace match case with if else to support python<3.10, option to save PNG to custom dir
+ (see `Settings/AnimateDiff` for detail), move hints to js, install imageio\[ffmpeg\] automatically when MP4 save fails.
 
 ## FAQ
 1.  Q: How much VRAM do I need?

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -4,17 +4,17 @@ if (titles) { // TODO: This is a conflict feature. If some other extension also 
     titles["FPS"]                   = "How many frames per second generated GIF will be.";
     titles["Display loop number"]   = "How many times the animation will loop when displayed, a value of 0 will loop forever.";
     titles["Closed loop"]           = "If enabled, will try to make the last frame the same as the first frame.";
-    titles["Context batch size"]    = "TODO";
-    titles["Stride"]                = "Adjusts the spacing between selected frames in the animation. A larger stride creates more variation between frames.";
-    titles["Overlap"]               = "Number of frames to overlap in context.";
-    titles["Save"]                  = "Which formats the animation should be saved in";
+    // titles["Context batch size"]    = "TODO";
+    // titles["Stride"]                = "TODO";
+    // titles["Overlap"]               = "TODO";
+    titles["Save format"]                  = "In which formats the animation should be saved.";
     titles["Reverse"]               = "Reverse the resulting animation, remove the first and/or last frame from duplication.";
     titles["Frame Interpolation"]   = "Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.";
     titles["Interp X"]              = "Replace each input frame with X interpolated output frames.";
-    titles["Video source"]          = "Paste path to video file.";
-    titles["Video path"]            = "TODO";
-    titles["Latent power"]          = "TODO";
-    titles["Latent scale"]          = "TODO";
-    titles["Optional latent power for last frame"] = "TODO";
-    titles["Optional latent scale for last frame"] = "TODO";
+    // titles["Video source"]          = "TODO";
+    // titles["Video path"]            = "TODO";
+    // titles["Latent power"]          = "TODO";
+    // titles["Latent scale"]          = "TODO";
+    // titles["Optional latent power for last frame"] = "TODO";
+    // titles["Optional latent scale for last frame"] = "TODO";
 }

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -1,0 +1,20 @@
+if (titles) { // TODO: This is a conflict feature. If some other extension also have the same textContent, they will also show this hint, or substitite this hint.
+    titles["Motion module"]         = "Choose which motion module to be injected into UNet.";
+    titles["Number of frames"]      = "Total length of video in frames.";
+    titles["FPS"]                   = "How many frames per second generated GIF will be.";
+    titles["Display loop number"]   = "How many times the animation will loop when displayed, a value of 0 will loop forever.";
+    titles["Closed loop"]           = "If enabled, will try to make the last frame the same as the first frame.";
+    titles["Context batch size"]    = "TODO";
+    titles["Stride"]                = "Adjusts the spacing between selected frames in the animation. A larger stride creates more variation between frames.";
+    titles["Overlap"]               = "Number of frames to overlap in context.";
+    titles["Save"]                  = "Which formats the animation should be saved in";
+    titles["Reverse"]               = "Reverse the resulting animation, remove the first and/or last frame from duplication.";
+    titles["Frame Interpolation"]   = "Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.";
+    titles["Interp X"]              = "Replace each input frame with X interpolated output frames.";
+    titles["Video source"]          = "Paste path to video file.";
+    titles["Video path"]            = "TODO";
+    titles["Latent power"]          = "TODO";
+    titles["Latent scale"]          = "TODO";
+    titles["Optional latent power for last frame"] = "TODO";
+    titles["Optional latent scale for last frame"] = "TODO";
+}

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -107,6 +107,16 @@ def on_ui_settings():
         )
     )
     shared.opts.add_option(
+        "animatediff_save_to_custom",
+        shared.OptionInfo(
+            False,
+            "Save frames to stable-diffusion-webui/outputs/{ txt|img }2img-images/AnimateDiff/{gif filename}/ "
+            "instead of stable-diffusion-webui/outputs/{ txt|img }2img-images/{date}/.",
+            gr.Checkbox,
+            section=section
+        )
+    )
+    shared.opts.add_option(
         "animatediff_xformers",
         shared.OptionInfo(
             "Optimize attention layers with xformers",

--- a/scripts/animatediff_infv2v.py
+++ b/scripts/animatediff_infv2v.py
@@ -82,21 +82,20 @@ class AnimateDiffInfV2V:
                 for control in cn_script.latest_network.control_params:
                     if control.control_model_type == ControlModelType.IPAdapter:
                         ip_adapter_key = list(control.hint_cond)[0]
-                        match ip_adapter_key:
-                            case "image_embeds":
-                                if control.hint_cond[ip_adapter_key].shape[0] > len(context):
-                                    control.hint_cond_backup = control.hint_cond[ip_adapter_key]
-                                    control.hint_cond[ip_adapter_key] = control.hint_cond[ip_adapter_key][context]
-                                if control.hr_hint_cond is not None and control.hr_hint_cond[ip_adapter_key].shape[0] > len(context):
-                                    control.hr_hint_cond_backup = control.hr_hint_cond[ip_adapter_key]
-                                    control.hr_hint_cond[ip_adapter_key] = control.hr_hint_cond[ip_adapter_key][context]
-                            case "hidden_states":
-                                if control.hint_cond[ip_adapter_key][-2].shape[0] > len(context):
-                                    control.hint_cond_backup = control.hint_cond[ip_adapter_key][-2]
-                                    control.hint_cond[ip_adapter_key][-2] = control.hint_cond[ip_adapter_key][-2][context]
-                                if control.hr_hint_cond is not None and control.hr_hint_cond[ip_adapter_key][-2].shape[0] > len(context):
-                                    control.hr_hint_cond_backup = control.hr_hint_cond[ip_adapter_key][-2]
-                                    control.hr_hint_cond[ip_adapter_key][-2] = control.hr_hint_cond[ip_adapter_key][-2][context]
+                        if ip_adapter_key == "image_embeds":
+                            if control.hint_cond[ip_adapter_key].shape[0] > len(context):
+                                control.hint_cond_backup = control.hint_cond[ip_adapter_key]
+                                control.hint_cond[ip_adapter_key] = control.hint_cond[ip_adapter_key][context]
+                            if control.hr_hint_cond is not None and control.hr_hint_cond[ip_adapter_key].shape[0] > len(context):
+                                control.hr_hint_cond_backup = control.hr_hint_cond[ip_adapter_key]
+                                control.hr_hint_cond[ip_adapter_key] = control.hr_hint_cond[ip_adapter_key][context]
+                        elif ip_adapter_key == "hidden_states":
+                            if control.hint_cond[ip_adapter_key][-2].shape[0] > len(context):
+                                control.hint_cond_backup = control.hint_cond[ip_adapter_key][-2]
+                                control.hint_cond[ip_adapter_key][-2] = control.hint_cond[ip_adapter_key][-2][context]
+                            if control.hr_hint_cond is not None and control.hr_hint_cond[ip_adapter_key][-2].shape[0] > len(context):
+                                control.hr_hint_cond_backup = control.hr_hint_cond[ip_adapter_key][-2]
+                                control.hr_hint_cond[ip_adapter_key][-2] = control.hr_hint_cond[ip_adapter_key][-2][context]
                     else:
                         if control.hint_cond.shape[0] > len(context):
                             control.hint_cond_backup = control.hint_cond
@@ -123,26 +122,24 @@ class AnimateDiffInfV2V:
                     if getattr(control, "hint_cond_backup", None) is not None:
                         if control.control_model_type == ControlModelType.IPAdapter:
                             ip_adapter_key = list(control.hint_cond_backup)[0]
-                            match ip_adapter_key:
-                                case "image_embeds":
-                                    control.hint_cond_backup[context] = control.hint_cond[ip_adapter_key]
-                                    control.hint_cond[ip_adapter_key] = control.hint_cond_backup
-                                case "hidden_states":
-                                    control.hint_cond_backup[context] = control.hint_cond[ip_adapter_key][-2]
-                                    control.hint_cond[ip_adapter_key][-2] = control.hint_cond_backup
+                            if ip_adapter_key == "image_embeds":
+                                control.hint_cond_backup[context] = control.hint_cond[ip_adapter_key]
+                                control.hint_cond[ip_adapter_key] = control.hint_cond_backup
+                            elif ip_adapter_key == "hidden_states":
+                                control.hint_cond_backup[context] = control.hint_cond[ip_adapter_key][-2]
+                                control.hint_cond[ip_adapter_key][-2] = control.hint_cond_backup
                         else:
                             control.hint_cond_backup[context] = control.hint_cond
                             control.hint_cond = control.hint_cond_backup
                     if control.hr_hint_cond is not None and getattr(control, "hr_hint_cond_backup", None) is not None:
                         if control.control_model_type == ControlModelType.IPAdapter:
                             ip_adapter_key = list(control.hr_hint_cond_backup)[0]
-                            match ip_adapter_key:
-                                case "image_embeds":
-                                    control.hr_hint_cond_backup[ip_adapter_key][context] = control.hr_hint_cond[ip_adapter_key]
-                                    control.hr_hint_cond[ip_adapter_key] = control.hr_hint_cond_backup[ip_adapter_key]
-                                case "hidden_states":
-                                    control.hr_hint_cond_backup[context] = control.hr_hint_cond[ip_adapter_key][-2]
-                                    control.hr_hint_cond[ip_adapter_key][-2] = control.hr_hint_cond_backup
+                            if ip_adapter_key == "image_embeds":
+                                control.hr_hint_cond_backup[ip_adapter_key][context] = control.hr_hint_cond[ip_adapter_key]
+                                control.hr_hint_cond[ip_adapter_key] = control.hr_hint_cond_backup[ip_adapter_key]
+                            elif ip_adapter_key == "hidden_states":
+                                control.hr_hint_cond_backup[context] = control.hr_hint_cond[ip_adapter_key][-2]
+                                control.hr_hint_cond[ip_adapter_key][-2] = control.hr_hint_cond_backup
                         else:
                             control.hr_hint_cond_backup[context] = control.hr_hint_cond
                             control.hr_hint_cond = control.hr_hint_cond_backup

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import imageio.v3 as imageio
 import numpy as np
-from PIL import Image
+from PIL import Image, PngImagePlugin
 from modules import images, shared
 from modules.processing import Processed, StableDiffusionProcessing
 
@@ -24,15 +24,14 @@ class AnimateDiffOutput:
             # so make a copy instead of a slice (reference), to avoid modifying res
             video_list = [image.copy() for image in res.images[i : i + params.video_length]]
 
-            seq = images.get_next_sequence_number(
-                f"{p.outpath_samples}/AnimateDiff", ""
-            )
+            seq = images.get_next_sequence_number(f"{p.outpath_samples}/AnimateDiff", "")
             filename = f"{seq:05}-{res.seed}"
-            video_path_prefix = f"{p.outpath_samples}/AnimateDiff/{filename}."
+            video_path_prefix = f"{p.outpath_samples}/AnimateDiff/{filename}"
 
             video_list = self._add_reverse(params, video_list)
             video_list = self._interp(p, params, video_list, filename)
             video_paths += self._save(params, video_list, video_path_prefix, res, i)
+
 
         if len(video_paths) > 0:
             if not p.is_api:
@@ -131,8 +130,16 @@ class AnimateDiffOutput:
     ):
         video_paths = []
         video_array = [np.array(v) for v in video_list]
+        if "PNG" in params.format and shared.opts.data.get("animatediff_save_to_custom", False):
+            Path(video_path_prefix).mkdir(exist_ok=True, parents=True)
+            for i, frame in enumerate(video_list):
+                png_filename = f"{video_path_prefix}/{i:05}.png"
+                png_info = PngImagePlugin.PngInfo()
+                png_info.add_text('parameters', res.infotexts[0])
+                imageio.imwrite(png_filename, frame, pnginfo=png_info)
+
         if "GIF" in params.format:
-            video_path_gif = video_path_prefix + "gif"
+            video_path_gif = video_path_prefix + ".gif"
             video_paths.append(video_path_gif)
             if shared.opts.data.get("animatediff_optimize_gif_palette", False):
                 try:
@@ -173,11 +180,11 @@ class AnimateDiffOutput:
             if shared.opts.data.get("animatediff_optimize_gif_gifsicle", False):
                 self._optimize_gif(video_path_gif)
         if "MP4" in params.format:
-            video_path_mp4 = video_path_prefix + "mp4"
+            video_path_mp4 = video_path_prefix + ".mp4"
             video_paths.append(video_path_mp4)
             imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
         if "TXT" in params.format and res.images[index].info is not None:
-            video_path_txt = video_path_prefix + "txt"
+            video_path_txt = video_path_prefix + ".txt"
             self._save_txt(params, video_path_txt, res, index)
         return video_paths
 

--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -182,7 +182,15 @@ class AnimateDiffOutput:
         if "MP4" in params.format:
             video_path_mp4 = video_path_prefix + ".mp4"
             video_paths.append(video_path_mp4)
-            imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
+            try:
+                imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
+            except:
+                from launch import run_pip
+                run_pip(
+                    "install imageio[ffmpeg]",
+                    "sd-webui-animatediff save mp4 requirement: imageio[ffmpeg]",
+                )
+                imageio.imwrite(video_path_mp4, video_array, fps=params.fps, codec="h264")
         if "TXT" in params.format and res.images[index].info is not None:
             video_path_txt = video_path_prefix + ".txt"
             self._save_txt(params, video_path_txt, res, index)
@@ -203,9 +211,7 @@ class AnimateDiffOutput:
             try:
                 pygifsicle.optimize(video_path)
             except FileNotFoundError:
-                logger.warn(
-                    "gifsicle not found, required for optimized GIFs, try: apt install gifsicle"
-                )
+                logger.warn("gifsicle not found, required for optimized GIFs, try: apt install gifsicle")
 
     def _save_txt(
         self, params: AnimateDiffProcess, video_path: str, res: Processed, i: int

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -3,6 +3,8 @@ import os
 import cv2
 import gradio as gr
 
+from modules import shared
+
 from scripts.animatediff_mm import mm_animatediff as motion_module
 
 
@@ -93,7 +95,7 @@ class AnimateDiffProcess:
             self.video_default = False
         if self.overlap == -1:
             self.overlap = self.batch_size // 4
-        if "PNG" not in self.format:
+        if "PNG" not in self.format or shared.opts.data.get("animatediff_save_to_custom", False):
             p.do_not_save_samples = True
 
 

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -192,7 +192,7 @@ class AnimateDiffUiGroup:
             with gr.Row():
                 self.params.format = gr.CheckboxGroup(
                     choices=["GIF", "MP4", "PNG", "TXT"],
-                    label="Save",
+                    label="Save format",
                     type="value",
                     elem_id=f"{elemid_prefix}save-format",
                     value=self.params.format,

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -133,13 +133,10 @@ class AnimateDiffUiGroup:
                     value=(self.params.model if self.params.model in model_list else None),
                     label="Motion module",
                     type="value",
-                    tooltip="Choose which motion module will be injected into the generation process.",
                     elem_id=f"{elemid_prefix}motion-module",
                 )
                 refresh_model = ToolButton(value="\U0001f504")
-                refresh_model.click(
-                    refresh_models, self.params.model, self.params.model
-                )
+                refresh_model.click(refresh_models, self.params.model, self.params.model)
             with gr.Row():
                 self.params.enable = gr.Checkbox(
                     value=self.params.enable, label="Enable AnimateDiff", 
@@ -150,12 +147,10 @@ class AnimateDiffUiGroup:
                     value=self.params.video_length,
                     label="Number of frames",
                     precision=0,
-                    tooltip="Total length of video in frames.",
                     elem_id=f"{elemid_prefix}video-length",
                 )
                 self.params.fps = gr.Number(
                     value=self.params.fps, label="FPS", precision=0, 
-                    tooltip="How many frames per second the gif will run.", 
                     elem_id=f"{elemid_prefix}fps"
                 )
                 self.params.loop_number = gr.Number(
@@ -163,14 +158,12 @@ class AnimateDiffUiGroup:
                     value=self.params.loop_number,
                     label="Display loop number",
                     precision=0,
-                    tooltip="How many times the animation will loop, a value of 0 will loop forever.",
                     elem_id=f"{elemid_prefix}loop-number",
                 )
             with gr.Row():
                 self.params.closed_loop = gr.Checkbox(
                     value=self.params.closed_loop,
                     label="Closed loop",
-                    tooltip="If enabled, will try to make the last frame the same as the first frame.",
                     elem_id=f"{elemid_prefix}closed-loop",
                 )
                 self.params.batch_size = gr.Slider(
@@ -187,7 +180,6 @@ class AnimateDiffUiGroup:
                     value=self.params.stride,
                     label="Stride",
                     precision=0,
-                    tooltip="",
                     elem_id=f"{elemid_prefix}stride",
                 )
                 self.params.overlap = gr.Number(
@@ -195,7 +187,6 @@ class AnimateDiffUiGroup:
                     value=self.params.overlap,
                     label="Overlap",
                     precision=0,
-                    tooltip="Number of frames to overlap in context.",
                     elem_id=f"{elemid_prefix}overlap",
                 )
             with gr.Row():
@@ -203,7 +194,6 @@ class AnimateDiffUiGroup:
                     choices=["GIF", "MP4", "PNG", "TXT"],
                     label="Save",
                     type="value",
-                    tooltip="Which formats the animation should be saved in",
                     elem_id=f"{elemid_prefix}save-format",
                     value=self.params.format,
                 )
@@ -211,7 +201,6 @@ class AnimateDiffUiGroup:
                     choices=["Add Reverse Frame", "Remove head", "Remove tail"],
                     label="Reverse",
                     type="index",
-                    tooltip="Reverse the resulting animation, remove the first and/or last frame from duplication.",
                     elem_id=f"{elemid_prefix}reverse",
                     value=self.params.reverse
                 )
@@ -219,13 +208,11 @@ class AnimateDiffUiGroup:
                 self.params.interp = gr.Radio(
                     choices=["Off", "FILM"],
                     label="Frame Interpolation",
-                    tooltip="Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension.",
                     elem_id=f"{elemid_prefix}interp-choice",
                     value=self.params.interp
                 )
                 self.params.interp_x = gr.Number(
                     value=self.params.interp_x, label="Interp X", precision=0, 
-                    tooltip="Replace each input frame with X interpolated output frames.", 
                     elem_id=f"{elemid_prefix}interp-x"
                 )
             self.params.video_source = gr.Video(
@@ -253,7 +240,6 @@ class AnimateDiffUiGroup:
             self.params.video_path = gr.Textbox(
                 value=self.params.video_path,
                 label="Video path",
-                tooltip="Paste path to video file.",
                 elem_id=f"{elemid_prefix}video-path"
             )
             if is_img2img:
@@ -264,7 +250,6 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_power,
                         step=0.1,
                         label="Latent power",
-                        tooltip="",
                         elem_id=f"{elemid_prefix}latent-power",
                     )
                     self.params.latent_scale = gr.Slider(
@@ -272,7 +257,6 @@ class AnimateDiffUiGroup:
                         maximum=128,
                         value=self.params.latent_scale,
                         label="Latent scale",
-                        tooltip="",
                         elem_id=f"{elemid_prefix}latent-scale"
                     )
                     self.params.latent_power_last = gr.Slider(
@@ -281,7 +265,6 @@ class AnimateDiffUiGroup:
                         value=self.params.latent_power_last,
                         step=0.1,
                         label="Optional latent power for last frame",
-                        tooltip="",
                         elem_id=f"{elemid_prefix}latent-power-last",
                     )
                     self.params.latent_scale_last = gr.Slider(
@@ -289,11 +272,10 @@ class AnimateDiffUiGroup:
                         maximum=128,
                         value=self.params.latent_scale_last,
                         label="Optional latent scale for last frame",
-                        tooltip="",
                         elem_id=f"{elemid_prefix}latent-scale-last"
                     )
                 self.params.last_frame = gr.Image(
-                    label="[Experiment] Optional last frame. Leave it blank if you do not need one.",
+                    label="Optional last frame. Leave it blank if you do not need one.",
                     type="pil",
                 )
             with gr.Row():


### PR DESCRIPTION
- [x] use state dict key to guess mm version
- [x] replace match case with if else close #192 
- [x] option to save to custom dir close #161 
- [x] move hints to js
- [x] install imageio[ffmpeg] automatically

The following updates will be postponded to 1.9.2 or later
- [ ] webp output format (merge PR by jared)
- [ ] sequential context generator
- [ ] let first prompt affect last prompt interpolation when closed loop
- [ ] png info - prompt travel, mm hash, etc
- [ ] vram optimization
- [ ] prompt travel w/ ip-adapter
- [ ] reference only
- [ ] i2i batch
- [ ] [controlnet per-frame weights](https://cdn.discordapp.com/attachments/1145365129324675182/1161223403676631071/1399556488.mp4?ex=65378491&is=65250f91&hm=ca2aebbb71256347e2c1b139e699f937d6cbe347d47409063e41289a0c590baf&)
- [ ] test upscale, refine, tile-upscale, stylize
- [ ] refactor SAM to support video inpainting
- [ ] readme refactor, also hints.js
- [ ] instruction video