### PR TITLE
1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,68 @@
 # AnimateDiff for Stable Diffusion WebUI
-
 This extension aim for integrating [AnimateDiff](https://github.com/guoyww/AnimateDiff/) w/ [CLI](https://github.com/s9roll7/animatediff-cli-prompt-travel) into [AUTOMATIC1111 Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) w/ [ControlNet](https://github.com/Mikubill/sd-webui-controlnet). You can generate GIFs in exactly the same way as generating images after enabling this extension.
 
 This extension implements AnimateDiff in a different way. It does not require you to clone the whole SD1.5 repository. It also applied (probably) the least modification to `ldm`, so that you do not need to reload your model weights if you don't want to.
 
-Batch size on WebUI will be replaced by GIF frame number internally: 1 full GIF generated in 1 batch. If you want to generate multiple GIF at once, please change batch number. 
-
-Batch number is NOT the same as batch size. In A1111 WebUI, batch number is above batch size. Batch number means the number of sequential steps, but batch size means the number of parallel steps. You do not have to worry too much when you increase batch number, but you do need to worry about your VRAM when you increase your batch size (where in this extension, video frame number). You do not need to change batch size at all when you are using this extension.
-
 You might also be interested in another extension I created: [Segment Anything for Stable Diffusion WebUI](https://github.com/continue-revolution/sd-webui-segment-anything).
 
-## How to Use
 
+## Table of Contents
+- [Update](#update)
+- [How to Use](#how-to-use)
+  - [WebUI](#webui)
+  - [API](#api)
+- [WebUI Parameters](#webui-parameters)
+- [Img2GIF](#img2gif)
+- [Motion LoRA](#motion-lora)
+- [Prompt Travel](#prompt-travel)
+- [ControlNet V2V](#controlnet-v2v)
+- [Motion Module Model Zoo](#motion-module-model-zoo)
+- [VRAM](#vram)
+- [Batch Size](#batch-size)
+- [FAQ](#faq)
+- [Demo](#demo)
+  - [Basic Usage](#basic-usage)
+  - [Motion LoRA](#motion-lora-1)
+  - [Prompt Travel](#prompt-travel-1)
+  - [ControlNet V2V](#controlnet-v2v-1)
+- [Tutorial](#tutorial)
+- [Thanks](#thanks)
+- [Star History](#star-history)
+- [Sponsor](#sponsor)
+
+
+## Update
+- `2023/07/20` [v1.1.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.1.0): Fix gif duration, add loop number, remove auto-download, remove xformers, remove instructions on gradio UI, refactor README, add [sponsor](#sponsor) QR code.
+- `2023/07/24` [v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0): Fix incorrect insertion of motion modules, add option to change path to motion modules in `Settings/AnimateDiff`, fix loading different motion modules.
+- `2023/09/04` [v1.3.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.3.0): Support any community models with the same architecture; fix grey problem via [#63](https://github.com/continue-revolution/sd-webui-animatediff/issues/63)
+- `2023/09/11` [v1.4.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.0): Support official v2 motion module (different architecture: GroupNorm not hacked, UNet middle layer has motion module).    
+- `2023/09/14`: [v1.4.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.1): Always change `beta`, `alpha_comprod` and `alpha_comprod_prev` to resolve grey problem in other samplers.
+- `2023/09/16`: [v1.5.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.0): Randomize init latent to support [better img2gif](#img2gif); add other output formats and infotext output; add appending reversed frames; refactor code to ease maintaining.
+- `2023/09/19`: [v1.5.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.1): Support xformers, sdp, sub-quadratic attention optimization - [VRAM](#vram) usage decrease to 5.60GB with default setting.
+- `2023/09/22`: [v1.5.2](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.2): Option to disable xformers at `Settings/AnimateDiff` [due to a bug in xformers](https://github.com/facebookresearch/xformers/issues/845), [API support](#api), option to enable GIF paletter optimization at `Settings/AnimateDiff`, gifsicle optimization move to `Settings/AnimateDiff`.
+- `2023/09/25`: [v1.6.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.6.0): [Motion LoRA](https://github.com/guoyww/AnimateDiff#features) supported. See [Motion Lora](#motion-lora) for more information.
+- `2023/09/27`: [v1.7.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.7.0): [ControlNet](https://github.com/Mikubill/sd-webui-controlnet) supported. See [ControlNet V2V](#controlnet-v2v) for more information. [Safetensors](#motion-module-model-zoo) for some motion modules are also available now.
+- `2023/09/29`: [v1.8.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.0): Infinite generation supported. See [WebUI Parameters](#webui-parameters) for more information.
+- `2023/10/01`: [v1.8.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.1): Now you can uncheck `Batch cond/uncond` in `Settings/Optimization` if you want. This will reduce your [VRAM](#vram) (5.31GB -> 4.21GB for SDP) but take longer time.
+- `2023/10/08`: [v1.9.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.0): Prompt travel supported. You must have ControlNet installed (you do not need to enable ControlNet) to try it. See [Prompt Travel](#prompt-travel) for how to trigger this feature.
+- `2023/10/11`: [v1.9.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): Use state_dict key to guess mm version, replace match case with if else to support python<3.10, option to save PNG to custom dir
+ (see `Settings/AnimateDiff` for detail), move hints to js, install imageio\[ffmpeg\] automatically when MP4 save fails.
+- `2023/10/16`: [v1.9.2](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.2): Add context generator to completely remove any closed loop, prompt travel support closed loop, infotext fully supported including prompt travel, README refactor
+
+
+## How to Use
 1. Update your WebUI to v1.6.0 and ControlNet to v1.1.410, then install this extension via link. I do not plan to support older version.
-1. Download motion modules and put the model weights under `stable-diffusion-webui/extensions/sd-webui-animatediff/model/`. If you want to use another directory to save the model weights, please go to `Settings/AnimateDiff`. See [model zoo](#motion-module-model-zoo) for a list of available motion modules.
+1. Download motion modules and put the model weights under `stable-diffusion-webui/extensions/sd-webui-animatediff/model/`. If you want to use another directory to save model weights, please go to `Settings/AnimateDiff`. See [model zoo](#motion-module-model-zoo) for a list of available motion modules.
 1. Enable `Pad prompt/negative prompt to be same length` in `Settings/Optimization` and click `Apply settings`. You must do this to prevent generating two separate unrelated GIFs. Checking `Batch cond/uncond` is optional, which can improve speed but increase VRAM usage.
 
 ### WebUI
 1. Go to txt2img if you want to try txt2gif and img2img if you want to try img2gif.
-1. Choose an SD1.5 checkpoint, write prompts, set configurations such as image width/height. If you want to generate multiple GIFs at once, please change batch number, instead of batch size.
-1. Enable AnimateDiff extension, and set up each parameter, and click `Generate`.
-   1. **Number of frames** — Choose whatever number you like. 
-      
-      If you enter 0 (default):
-      - If you submit a video via `Video source` / enter a video path via `Video path` / enable ANY batch ControlNet, the number of frames will be the number of frames in the video (use shortest if more than one videos are submitted).
-      - Otherwise, the number of frames will be your `Batch size` described below.
-
-      If you enter something smaller than your `Batch size` other than 0: you will get the first `Number of frames` frames as your output GIF from your whole generation. All following frames will not appear in your generated GIF, but will be saved as PNGs as usual.
-   1. **FPS** — Frames per second, which is how many frames (images) are shown every second. If 16 frames are generated at 8 frames per second, your GIF’s duration is 2 seconds. If you submit a source video, your FPS will be the same as the source video.
-   1. **Display loop number** — How many times the GIF is played. A value of `0` means the GIF never stops playing.
-   1. **Batch size** — How many frames will be passed into the motion module at once. The model is trained with 16 frames, so it’ll give the best results when the number of frames is set to `16`. Choose [1, 24] for V1 motion modules and [1, 32] for V2 motion modules.
-   1. **Closed loop** — If you enable this option and your number of frames is greater than your batch size, this extension will try to make the last frame the same as the first frame.
-   1. **Stride** — Max motion stride as a power of 2 (default: 1).
-   1. **Overlap** — Number of frames to overlap in context. If overlap is -1 (default): your overlap will be `Batch size` // 4.
-   1. **Save** — Format of the output. Choose at least one of "GIF"|"MP4"|"PNG". Check "TXT" if you want infotext, which will live in the same directory as the output GIF.
-        1. You can optimize GIF with `gifsicle` (`apt install gifsicle` required, read [#91](https://github.com/continue-revolution/sd-webui-animatediff/pull/91) for more information) and/or `palette` (read [#104](https://github.com/continue-revolution/sd-webui-animatediff/pull/104) for more information). Go to `Settings/AnimateDiff` to enable them.
-   1. **Reverse** — Append reversed frames to your output. See [#112](https://github.com/continue-revolution/sd-webui-animatediff/issues/112) for instruction.
-   1. **Frame Interpolation** Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension. [#128](https://github.com/continue-revolution/sd-webui-animatediff/pull/128)
-   1. **Interp X** Replace each input frame with X interpolated output frames. [#128](https://github.com/continue-revolution/sd-webui-animatediff/pull/128).
-   1. **Video source** — [Optional] Video source file for video to video generation. You MUST enable ControlNet. It will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet panel. You can of course submit a control image via `Single Image` tab or an input directory via `Batch` tab, they will override this video source input and work as usual.
-   1. **Video path** — [Optional] Folder for source frames for video to video generation, but lower priority than `Video source`. You MUST enable ControlNet. It will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet. You can of course submit a control image via `Single Image` tab or an input directory via `Batch` tab, they will override this video path input and work as usual.
-      - For people who want to inpaint videos: enter a folder which contains two sub-folders `image` and `mask`. They should contain the same number of images. This extension will match them according to the same sequence. You should not upload a video directly to **Video source** mentioned above. Using my [Segment Anything](https://github.com/continue-revolution/sd-webui-segment-anything) extension can make your life much easier.
-1. You should see the output GIF on the output gallery. You can access GIF output at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/AnimateDiff`. You can also access image frames at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/{date}`.
-
-#### img2GIF
-
-You need to go to img2img and submit an init frame via A1111 panel. You can optionally submit a last frame via extension panel (experiment feature, not tested, not sure if it will work).
-
-By default: your `init_latent` will be changed to 
-```
-init_alpha = (1 - frame_number ^ latent_power / latent_scale)
-init_latent = init_latent * init_alpha + random_tensor * (1 - init_alpha)
-```
-
-If you upload a last frame: your `init_latent` will be changed in a similar way. Read [this code](https://github.com/continue-revolution/sd-webui-animatediff/tree/v1.5.0/scripts/animatediff_latent.py#L28-L65) to understand how it works.
+1. Choose an SD1.5 checkpoint, write prompts, set configurations such as image width/height. If you want to generate multiple GIFs at once, please [change batch number, instead of batch size](#batch-size).
+1. Enable AnimateDiff extension, set up [each parameter](#webui-parameters), then click `Generate`.
+1. You should see the output GIF on the output gallery. You can access GIF output at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/AnimateDiff`. You can also access image frames at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/{date}`. You may choose to save frames for each generation into separate directories in `Settings/AnimateDiff`.
 
 ### API
-Just like how you use ControlNet. Here is a sample. You will get a list of generated frames. You will have to view GIF in your file system, as mentioned at [#WebUI](#webui) item 4.
+Just like how you use ControlNet. Here is a **stale** sample. You will get a list of generated frames. You will have to view GIF in your file system, as mentioned at [WebUI](#webui) item 4. For most up-to-date parameters, please read [here](https://github.com/continue-revolution/sd-webui-animatediff/blob/master/scripts/animatediff_ui.py#L26).
 ```
 'alwayson_scripts': {
   'AnimateDiff': {
@@ -80,76 +86,156 @@ Just like how you use ControlNet. Here is a sample. You will get a list of gener
 },
 ```
 
+
+## WebUI Parameters
+1. **Number of frames** — Choose whatever number you like. 
+
+    If you enter 0 (default):
+    - If you submit a video via `Video source` / enter a video path via `Video path` / enable ANY batch ControlNet, the number of frames will be the number of frames in the video (use shortest if more than one videos are submitted).
+    - Otherwise, the number of frames will be your `Context batch size` described below.
+
+    If you enter something smaller than your `Context batch size` other than 0: you will get the first `Number of frames` frames as your output GIF from your whole generation. All following frames will not appear in your generated GIF, but will be saved as PNGs as usual. Do not set `Number of frames` to be something smaler than `Context batch size` other than 0 because of [#213](https://github.com/continue-revolution/sd-webui-animatediff/issues/213).
+1. **FPS** — Frames per second, which is how many frames (images) are shown every second. If 16 frames are generated at 8 frames per second, your GIF’s duration is 2 seconds. If you submit a source video, your FPS will be the same as the source video.
+1. **Display loop number** — How many times the GIF is played. A value of `0` means the GIF never stops playing.
+1. **Context batch size** — How many frames will be passed into the motion module at once. The model is trained with 16 frames, so it’ll give the best results when the number of frames is set to `16`. Choose [1, 24] for V1 motion modules and [1, 32] for V2 motion modules.
+1. **Closed loop** — Closed loop means that this extension will try to make the last frame the same as the first frame. Closed loop can only be made possible when `Number of frames` is greater than `Context batch size`, including when ControlNet is enabled and the source video frame number is greater than `Context batch size` and `Number of frames` is 0.
+    - `N` means absolutely no closed loop - this is the only available option if `Number of frames` is smaller than `Context batch size` other than 0.
+    - `R-P` means that the extension will try to reduce the number of closed loop context. The prompt travel will not be interpolated to be a closed loop.
+    - `R+P` means that the extension will try to reduce the number of closed loop context. The prompt travel will be interpolated to be a closed loop.
+    - `A` means that the extension will aggressively try to make the last frame the same as the first frame. The prompt travel will be interpolated to be a closed loop.
+1. **Stride** — Max motion stride as a power of 2 (default: 1). TODO - Need more clear explanation.
+1. **Overlap** — Number of frames to overlap in context. If overlap is -1 (default): your overlap will be `Context batch size` // 4.
+1. **Save** — Format of the output. Choose at least one of "GIF"|"MP4"|"PNG". Check "TXT" if you want infotext, which will live in the same directory as the output GIF.
+    1. You can optimize GIF with `gifsicle` (`apt install gifsicle` required, read [#91](https://github.com/continue-revolution/sd-webui-animatediff/pull/91) for more information) and/or `palette` (read [#104](https://github.com/continue-revolution/sd-webui-animatediff/pull/104) for more information). Go to `Settings/AnimateDiff` to enable them.
+1. **Reverse** — Append reversed frames to your output. See [#112](https://github.com/continue-revolution/sd-webui-animatediff/issues/112) for instruction.
+1. **Frame Interpolation** — Interpolate between frames with Deforum's FILM implementation. Requires Deforum extension. [#128](https://github.com/continue-revolution/sd-webui-animatediff/pull/128)
+1. **Interp X** — Replace each input frame with X interpolated output frames. [#128](https://github.com/continue-revolution/sd-webui-animatediff/pull/128).
+1. **Video source** — [Optional] Video source file for [ControlNet V2V](#controlnet-v2v). You MUST enable ControlNet. It will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet panel. You can of course submit one control image via `Single Image` tab or an input directory via `Batch` tab, which will override this video source input and work as usual.
+1. **Video path** — [Optional] Folder for source frames for [ControlNet V2V](#controlnet-v2v), but lower priority than `Video source`. You MUST enable ControlNet. It will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet. You can of course submit one control image via `Single Image` tab or an input directory via `Batch` tab, which will override this video path input and work as usual.
+  - For people who want to inpaint videos: enter a folder which contains two sub-folders `image` and `mask` on ControlNet inpainting unit. These two sub-folders should contain the same number of images. This extension will match them according to the same sequence. Using my [Segment Anything](https://github.com/continue-revolution/sd-webui-segment-anything) extension can make your life much easier.
+
+Please read
+- [Img2GIF](#img2gif) for extra parameters on img2gif panel. For how to use Motion LoRA, please read 
+- [Motion LoRA](#motion-lora) for how to use Motion LoRA.
+- [Prompt Travel](#prompt-travel) for how to trigger prompt travel.
+- [ControlNet V2V](#controlnet-v2v) for how to use ControlNet V2V.
+
+
+## Img2GIF
+You need to go to img2img and submit an init frame via A1111 panel. You can optionally submit a last frame via extension panel.
+
+By default: your `init_latent` will be changed to 
+```
+init_alpha = (1 - frame_number ^ latent_power / latent_scale)
+init_latent = init_latent * init_alpha + random_tensor * (1 - init_alpha)
+```
+
+If you upload a last frame: your `init_latent` will be changed in a similar way. Read [this code](https://github.com/continue-revolution/sd-webui-animatediff/tree/v1.5.0/scripts/animatediff_latent.py#L28-L65) to understand how it works.
+
+
+## Motion LoRA
+[Download](https://huggingface.co/guoyww/animatediff) and use them like any other LoRA you use (example: download motion lora to `stable-diffusion-webui/models/Lora` and add `<lora:v2_lora_PanDown:0.8>` to your positive prompt). **Motion LoRA only supports V2 motion modules**.
+
+
+## Prompt Travel
+Write positive prompt following the example below.
+
+The first line is head prompt, which is optional. You can write no/single/multiple lines of head prompts.
+
+The second and third lines are for prompt interpolation, in format `frame number`: `prompt`. Your `frame number` should be in ascending order, smaller than the total `Number of frames`. The first frame is 0 index.
+
+The last line is tail prompt, which is optional. You can write no/single/multiple lines of tail prompts. If you don't need this feature, just write prompts in the old way.
+```
+1girl, yoimiya (genshin impact), origen, line, comet, wink, Masterpiece, BestQuality. UltraDetailed, <lora:LineLine2D:0.7>,  <lora:yoimiya:0.8>, 
+0: closed mouth
+8: open mouth
+smile
+```
+
+
+## ControlNet V2V
+Each ControlNet will find control images according to this priority:
+1. ControlNet `Single Image` tab or `Batch` tab. Simply upload a control image or a directory of control frames is enough.
+1. AnimateDiff `Video Source`. If you upload a video through `Video Source`, it will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet panel.
+1. AnimateDiff `Video Path`. If you upload a video through `Video Path`, it will be the source control for ALL ControlNet units that you enable without submitting a control image or a path to ControlNet panel.
+
+`Number of frames` will be capped to the minimum number of images among all **folders** you provide. Each control image in each folder will be applied to one single frame. If you upload one single image for a ControlNet unit, that image will control **ALL** frames.
+
+For people who want to inpaint videos: enter a folder which contains two sub-folders `image` and `mask` on ControlNet inpainting unit. These two sub-folders should contain the same number of images. This extension will match them according to the same sequence. Using my [Segment Anything](https://github.com/continue-revolution/sd-webui-segment-anything) extension can make your life much easier.
+
+
 ## Motion Module Model Zoo
 - `mm_sd_v14.ckpt` & `mm_sd_v15.ckpt` & `mm_sd_v15_v2.ckpt` by [@guoyww](https://github.com/guoyww): [Google Drive](https://drive.google.com/drive/folders/1EqLC65eR1-W-sGD0Im7fkED6c8GkiNFI) | [HuggingFace](https://huggingface.co/guoyww/animatediff) | [CivitAI](https://civitai.com/models/108836) | [Baidu NetDisk](https://pan.baidu.com/s/18ZpcSM6poBqxWNHtnyMcxg?pwd=et8y)
 - `mm_sd_v14.safetensors` & `mm_sd_v15.safetensors` & `mm_sd_v15_v2.safetensors` by [@neph1](https://github.com/neph1): [HuggingFace](https://huggingface.co/guoyww/animatediff/tree/refs%2Fpr%2F3)
 - `mm-Stabilized_high.pth` & `mm-Stabbilized_mid.pth` by [@manshoety](https://huggingface.co/manshoety): [HuggingFace](https://huggingface.co/manshoety/AD_Stabilized_Motion/tree/main)
 - `temporaldiff-v1-animatediff.ckpt` by [@CiaraRowles](https://huggingface.co/CiaraRowles): [HuggingFace](https://huggingface.co/CiaraRowles/TemporalDiff/tree/main)
 
-## Update
 
-- `2023/07/20` [v1.1.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.1.0): Fix gif duration, add loop number, remove auto-download, remove xformers, remove instructions on gradio UI, refactor README, add [sponsor](#sponsor) QR code.
-- `2023/07/24` [v1.2.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.2.0): Fix incorrect insertion of motion modules, add option to change path to save motion modules in Settings/AnimateDiff, fix loading different motion modules.
-- `2023/09/04` [v1.3.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.3.0): Support any community models with the same architecture; fix grey problem via [#63](https://github.com/continue-revolution/sd-webui-animatediff/issues/63) (credit to [@TDS4874](https://github.com/TDS4874) and [@opparco](https://github.com/opparco))
-- `2023/09/11` [v1.4.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.0): Support official v2 motion module (different architecture: GroupNorm not hacked, UNet middle layer has motion module).    
-- `2023/09/14`: [v1.4.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.4.1): Always change `beta`, `alpha_comprod` and `alpha_comprod_prev` to resolve grey problem in other samplers.
-- `2023/09/16`: [v1.5.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.0): Randomize init latent to support better img2gif, credit to [this forked repo](https://github.com/talesofai/AnimateDiff); add other output formats and infotext output, credit to [@zappityzap](https://github.com/zappityzap); add appending reversed frames; refactor code to ease maintaining.
-- `2023/09/19`: [v1.5.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.1): Support xformers, sdp, sub-quadratic attention optimization - VRAM usage decrease to 5.60GB with default setting. See [FAQ](#faq) 1st item for more information.
-- `2023/09/22`: [v1.5.2](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.5.2): Option to disable xformers at `Settings/AnimateDiff` [due to a bug in xformers](https://github.com/facebookresearch/xformers/issues/845), API support, option to enable GIF paletter optimization at `Settings/AnimateDiff` (credit to [@rkfg](https://github.com/rkfg)), gifsicle optimization move to `Settings/AnimateDiff`.
-- `2023/09/25`: [v1.6.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.6.0): [Motion LoRA](https://github.com/guoyww/AnimateDiff#features) supported. Download and use them like any other LoRA you use (example: download motion lora to `stable-diffusion-webui/models/Lora` and add `<lora:v2_lora_PanDown:0.8>` to your positive prompt). **Motion LoRA only supports V2 motion modules**.
-- `2023/09/27`: [v1.7.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.7.0): [ControlNet](https://github.com/Mikubill/sd-webui-controlnet) supported. Please closely follow the instructions in [How to Use](#how-to-use), especially the explanation of `Video source` and `Video path` attributes. ControlNet is way more complex than what I can test and I ask you to test for me. Please submit an issue whenever you find a bug. You may want to check `Do not append detectmap to output` in `Settings/ControlNet` to avoid having a series of control images in your output gallery. [Safetensors](#motion-module-model-zoo) for some motion modules are also available now.
-- `2023/09/29`: [v1.8.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.0): Infinite generation (with/without ControlNet) supported.
-- `2023/10/01`: [v1.8.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.8.1): Now you can uncheck `Batch cond/uncond` in `Settings/Optimization` if you want. This will reduce your VRAM (5.31GB -> 4.21GB for SDP) but take longer time.
-- `2023/10/08`: [v1.9.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.0): Prompt travel supported. You must have ControlNet installed (you do not need to enable ControlNet) to try it. See [FAQ](#faq) for how to trigger this feature.
-- `2023/10/11`: [v1.9.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): Use state_dict key to guess mm version, replace match case with if else to support python<3.10, option to save PNG to custom dir
- (see `Settings/AnimateDiff` for detail), move hints to js, install imageio\[ffmpeg\] automatically when MP4 save fails.
-- `2023/10/??`: [v1.9.2](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.2): TODO
+## VRAM
+Actual VRAM usage depends on your image size and context batch size. You can try to reduce image size or context batch size to reduce VRAM usage. I list some data tested on Ubuntu 22.04, NVIDIA 4090, torch 2.0.1+cu117, H=W=512, frame=16 (default setting) below. `w/`/`w/o` means `Batch cond/uncond` in `Settings/Optimization` is checked/unchecked.
+| Optimization | VRAM w/ | VRAM w/o |
+| --- | --- | --- |
+| No optimization | 12.13GB |  |
+| xformers/sdp | 5.60GB | 4.21GB |
+| sub-quadratic | 10.39GB |  |
+
+
+## Batch Size 
+Batch size on WebUI will be replaced by GIF frame number internally: 1 full GIF generated in 1 batch. If you want to generate multiple GIF at once, please change batch number. 
+
+Batch number is NOT the same as batch size. In A1111 WebUI, batch number is above batch size. Batch number means the number of sequential steps, but batch size means the number of parallel steps. You do not have to worry too much when you increase batch number, but you do need to worry about your VRAM when you increase your batch size (where in this extension, video frame number). You do not need to change batch size at all when you are using this extension.
+
+We are currently developing approach to support batch size on WebUI in the near future.
+
 
 ## FAQ
-1.  Q: How much VRAM do I need?
-
-    A: Actual VRAM usage depends on your image size and context batch size. You can try to reduce image size or context batch size to reduce VRAM usage. I list some data tested on Ubuntu 22.04, NVIDIA 4090, torch 2.0.1+cu117, H=W=512, frame=16 (default setting) below. `w/`/`w/o` means `Batch cond/uncond` in `Settings/Optimization` is checked/unchecked.
-    | Optimization | VRAM w/ | VRAM w/o |
-    | --- | --- | --- |
-    | No optimization | 12.13GB |  |
-    | xformers/sdp | 5.60GB | 4.21GB |
-    | sub-quadratic | 10.39GB |  |
-
 1.  Q: Can I use SDXL to generate GIFs?
 
     A: You will have to wait for someone to train SDXL-specific motion modules which will have a different model architecture. This extension essentially inject multiple motion modules into SD1.5 UNet. It does not work for other variations of SD, such as SD2.1 and SDXL.
 
-1.  Q: How should I write prompts to trigger prompt travel?
+1.  Q: Will ADetailer be supported?
 
-    A: See example below. The first line is head prompt, which is optional. You can write no/single/multiple lines of head prompts. The second and third lines are for prompt interpolation, in format `frame number`: `prompt`. The last line is tail prompt, which is optional. You can write no/single/multiple lines of tail prompts. If you don't need this feature, just write prompts in the old way.
-    ```
-    1girl, yoimiya (genshin impact), origen, line, comet, wink, Masterpiece, BestQuality. UltraDetailed, <lora:LineLine2D:0.7>,  <lora:yoimiya:0.8>, 
-    0: closed mouth
-    8: open mouth
-    smile
-    ```
+    A: I'm not planning to support ADetailer. However, I plan to refactor my [Segment Anything](https://github.com/continue-revolution/sd-webui-segment-anything) to achieve similar effects.
 
 
-## Demo and Video Instructions
+## Demo
 
-Coming soon.
-
-## Samples
-
-| AnimateDiff | Extension v1.2.0 | Extension v1.3.0 | img2img |
-| --- | --- | --- | --- |
-| ![image](https://user-images.githubusercontent.com/63914308/255306527-5105afe8-d497-4ab1-b5c4-37540e9601f8.gif) | ![00023-10788741199826055168](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/c35a952a-a127-491b-876d-cda97771f7ee) | ![00013-10788741199826055000](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/43b9cf34-dbd1-4120-b220-ea8cb7882272) | ![00018-727621716](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/d04bb573-c8ca-4ae6-a2d9-81f8012bec3a) |
-
-Note that I did not modify random tensor generation when producing v1.3.0 samples.
+### Basic Usage
+| AnimateDiff | Extension | img2img |
+| --- | --- | --- |
+| ![image](https://user-images.githubusercontent.com/63914308/255306527-5105afe8-d497-4ab1-b5c4-37540e9601f8.gif) |![00013-10788741199826055000](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/43b9cf34-dbd1-4120-b220-ea8cb7882272) | ![00018-727621716](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/d04bb573-c8ca-4ae6-a2d9-81f8012bec3a) |
 
 ### Motion LoRA
-
 | No LoRA | PanDown | PanLeft |
 | --- | --- | --- |
 | ![00094-1401397431](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/d8d2b860-c781-4dd0-8c0a-0eb26970130b) | ![00095-3197605735](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/aed2243f-5494-4fe3-a10a-96c57f6f2906) | ![00093-2722547708](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/c32e9aaf-54f2-4f40-879b-e800c7c7848c) |
 
-## Star History
+### Prompt Travel
+TODO 
 
+### ControlNet V2V
+TODO
+
+
+## Tutorial 
+TODO
+
+
+## Thanks
+I thank researchers from [Shanghai AI Lab](https://www.shlab.org.cn/), especially [@guoyww](https://github.com/guoyww) for creating AnimateDiff. I also thank [@neggles](https://github.com/neggles) and [@s9roll7](https://github.com/s9roll7) for creating and improving [AnimateDiff CLI Prompt Travel](https://github.com/s9roll7/animatediff-cli-prompt-travel). This extension could not be made possible without these creative works.
+
+I also thank community developers, especially
+- [@talesofai](https://github.com/talesofai) who developed i2v in [this forked repo](https://github.com/talesofai/AnimateDiff)
+- [@zappityzap](https://github.com/zappityzap) who developed the majority of the [output features](https://github.com/continue-revolution/sd-webui-animatediff/blob/master/scripts/animatediff_output.py)
+- [@TDS4874](https://github.com/TDS4874) and [@opparco](https://github.com/opparco) for resolving the grey issue which significantly improve the performance of this extension
+- [@rkfg](https://github.com/rkfg) for developing GIF palette optimization
+
+and many others who have contributed to this extension.
+
+I also thank community users, especially [@streamline](https://twitter.com/kaizirod) who provided dataset and workflow of ControlNet V2V. His workflow is extremely amazing and definitely worth checking out.
+
+
+## Star History
 <a href="https://star-history.com/#continue-revolution/sd-webui-animatediff&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=continue-revolution/sd-webui-animatediff&type=Date&theme=dark" />
@@ -160,7 +246,7 @@ Note that I did not modify random tensor generation when producing v1.3.0 sample
 
 
 ## Sponsor
-You can sponsor me via WeChat, AliPay or PayPal. You can also support me via [patreon](https://www.patreon.com/conrevo), [ko-fi](https://ko-fi.com/conrevo) or [afdian](https://afdian.net/a/conrevo).
+You can sponsor me via WeChat, AliPay or [PayPal](https://paypal.me/conrevo). You can also support me via [patreon](https://www.patreon.com/conrevo), [ko-fi](https://ko-fi.com/conrevo) or [afdian](https://afdian.net/a/conrevo).
 
 | WeChat | AliPay | PayPal |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You might also be interested in another extension I created: [Segment Anything f
 1. You should see the output GIF on the output gallery. You can access GIF output at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/AnimateDiff`. You can also access image frames at `stable-diffusion-webui/outputs/{txt2img or img2img}-images/{date}`. You may choose to save frames for each generation into separate directories in `Settings/AnimateDiff`.
 
 ### API
-Just like how you use ControlNet. Here is a **stale** sample. You will get a list of generated frames. You will have to view GIF in your file system, as mentioned at [WebUI](#webui) item 4. For most up-to-date parameters, please read [here](https://github.com/continue-revolution/sd-webui-animatediff/blob/master/scripts/animatediff_ui.py#L26).
+Just like how you use ControlNet. Here is a **stale** sample. (TODO: Update API Sample.) You will get a list of generated frames. You will have to view GIF in your file system, as mentioned at [WebUI](#webui) item 4. For most up-to-date parameters, please read [here](https://github.com/continue-revolution/sd-webui-animatediff/blob/master/scripts/animatediff_ui.py#L26).
 ```
 'alwayson_scripts': {
   'AnimateDiff': {
@@ -211,7 +211,9 @@ We are currently developing approach to support batch size on WebUI in the near 
 | ![00094-1401397431](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/d8d2b860-c781-4dd0-8c0a-0eb26970130b) | ![00095-3197605735](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/aed2243f-5494-4fe3-a10a-96c57f6f2906) | ![00093-2722547708](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/c32e9aaf-54f2-4f40-879b-e800c7c7848c) |
 
 ### Prompt Travel
-TODO 
+![00201-2296305953](https://github.com/continue-revolution/sd-webui-animatediff/assets/63914308/881f317c-f1d2-4635-b84b-b4c4881650f6)
+
+The prompt is similar to [above](#prompt-travel).
 
 ### ControlNet V2V
 TODO

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Just like how you use ControlNet. Here is a sample. You will get a list of gener
 - `2023/10/08`: [v1.9.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.0): Prompt travel supported. You must have ControlNet installed (you do not need to enable ControlNet) to try it. See [FAQ](#faq) for how to trigger this feature.
 - `2023/10/11`: [v1.9.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.1): Use state_dict key to guess mm version, replace match case with if else to support python<3.10, option to save PNG to custom dir
  (see `Settings/AnimateDiff` for detail), move hints to js, install imageio\[ffmpeg\] automatically when MP4 save fails.
+- `2023/10/??`: [v1.9.2](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.9.2): TODO
 
 ## FAQ
 1.  Q: How much VRAM do I need?

--- a/javascript/hints.js
+++ b/javascript/hints.js
@@ -3,7 +3,7 @@ if (titles) { // TODO: This is a conflict feature. If some other extension also 
     titles["Number of frames"]      = "Total length of video in frames.";
     titles["FPS"]                   = "How many frames per second generated GIF will be.";
     titles["Display loop number"]   = "How many times the animation will loop when displayed, a value of 0 will loop forever.";
-    titles["Closed loop"]           = "If enabled, will try to make the last frame the same as the first frame.";
+    // titles["Closed loop"]           = "If enabled, will try to make the last frame the same as the first frame.";
     // titles["Context batch size"]    = "TODO";
     // titles["Stride"]                = "TODO";
     // titles["Overlap"]               = "TODO";

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -14,6 +14,7 @@ from scripts.animatediff_mm import mm_animatediff as motion_module
 from scripts.animatediff_prompt import AnimateDiffPromptSchedule
 from scripts.animatediff_output import AnimateDiffOutput
 from scripts.animatediff_ui import AnimateDiffProcess, AnimateDiffUiGroup
+from scripts.animatediff_infotext import update_infotext
 
 script_dir = scripts.basedir()
 motion_module.set_script_dir(script_dir)
@@ -54,6 +55,7 @@ class AnimateDiffScript(scripts.Script):
             self.cfg_hacker.hack(params)
             self.cn_hacker = AnimateDiffControl(p, self.prompt_scheduler)
             self.cn_hacker.hack(params)
+            update_infotext(p, params)
 
 
     def before_process_batch(self, p: StableDiffusionProcessing, params: AnimateDiffProcess, **kwargs):
@@ -65,6 +67,7 @@ class AnimateDiffScript(scripts.Script):
     def postprocess(self, p: StableDiffusionProcessing, res: Processed, params: AnimateDiffProcess):
         if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable:
+            self.prompt_scheduler.set_infotext(res)
             self.cn_hacker.restore()
             self.cfg_hacker.restore()
             self.lora_hacker.restore()

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -56,17 +56,13 @@ class AnimateDiffScript(scripts.Script):
             self.cn_hacker.hack(params)
 
 
-    def before_process_batch(
-        self, p: StableDiffusionProcessing, params: AnimateDiffProcess, **kwargs
-    ):
+    def before_process_batch(self, p: StableDiffusionProcessing, params: AnimateDiffProcess, **kwargs):
         if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable and isinstance(p, StableDiffusionProcessingImg2Img):
             AnimateDiffI2VLatent().randomize(p, params)
 
 
-    def postprocess(
-        self, p: StableDiffusionProcessing, res: Processed, params: AnimateDiffProcess
-    ):
+    def postprocess(self, p: StableDiffusionProcessing, res: Processed, params: AnimateDiffProcess):
         if isinstance(params, dict): params = AnimateDiffProcess(**params)
         if params.enable:
             self.cn_hacker.restore()

--- a/scripts/animatediff_cn.py
+++ b/scripts/animatediff_cn.py
@@ -14,6 +14,7 @@ from modules.processing import (StableDiffusionProcessing,
 from scripts.animatediff_logger import logger_animatediff as logger
 from scripts.animatediff_ui import AnimateDiffProcess
 from scripts.animatediff_prompt import AnimateDiffPromptSchedule
+from scripts.animatediff_infotext import update_infotext
 
 
 class AnimateDiffControl:
@@ -54,7 +55,7 @@ class AnimateDiffControl:
 
         from scripts import external_code
         from scripts.batch_hijack import InputMode, BatchHijack, instance
-        def hacked_processing_process_images_hijack(self, p, *args, **kwargs):
+        def hacked_processing_process_images_hijack(self, p: StableDiffusionProcessing, *args, **kwargs):
             if self.is_batch: # AnimateDiff does not support this.
                 # we are in img2img batch tab, do a single batch iteration
                 return self.process_images_cn_batch(p, *args, **kwargs)
@@ -105,6 +106,7 @@ class AnimateDiffControl:
                             unit.batch_images = unit.batch_images[:params.video_length]
 
             prompt_scheduler.parse_prompt(p)
+            update_infotext(p, params)
             return getattr(processing, '__controlnet_original_process_images_inner')(p, *args, **kwargs)
         
         self.original_processing_process_images_hijack = BatchHijack.processing_process_images_hijack

--- a/scripts/animatediff_infotext.py
+++ b/scripts/animatediff_infotext.py
@@ -1,0 +1,16 @@
+import os
+
+from modules.paths import data_path
+from modules.processing import StableDiffusionProcessing, StableDiffusionProcessingImg2Img
+
+from scripts.animatediff_ui import AnimateDiffProcess
+
+
+def update_infotext(p: StableDiffusionProcessing, params: AnimateDiffProcess):
+    if p.extra_generation_params is not None:
+        p.extra_generation_params["AnimateDiff"] = params.get_dict(isinstance(p, StableDiffusionProcessingImg2Img))
+
+
+def write_params_txt(info: str):
+    with open(os.path.join(data_path, "params.txt"), "w", encoding="utf8") as file:
+        file.write(info)

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -28,7 +28,7 @@ class AnimateDiffProcess:
         video_length=0,
         fps=8,
         loop_number=0,
-        closed_loop=False,
+        closed_loop='reduce',
         batch_size=16,
         stride=1,
         overlap=-1,
@@ -161,7 +161,8 @@ class AnimateDiffUiGroup:
                     elem_id=f"{elemid_prefix}loop-number",
                 )
             with gr.Row():
-                self.params.closed_loop = gr.Checkbox(
+                self.params.closed_loop = gr.Radio(
+                    choices=["no", "reduce", "aggressive"],
                     value=self.params.closed_loop,
                     label="Closed loop",
                     elem_id=f"{elemid_prefix}closed-loop",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -28,7 +28,7 @@ class AnimateDiffProcess:
         video_length=0,
         fps=8,
         loop_number=0,
-        closed_loop='reduce',
+        closed_loop='R-P',
         batch_size=16,
         stride=1,
         overlap=-1,
@@ -162,7 +162,7 @@ class AnimateDiffUiGroup:
                 )
             with gr.Row():
                 self.params.closed_loop = gr.Radio(
-                    choices=["no", "reduce", "aggressive"],
+                    choices=["N", "R-P", "R+P", "A"],
                     value=self.params.closed_loop,
                     label="Closed loop",
                     elem_id=f"{elemid_prefix}closed-loop",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -4,6 +4,7 @@ import cv2
 import gradio as gr
 
 from modules import shared
+from modules.processing import StableDiffusionProcessing
 
 from scripts.animatediff_mm import mm_animatediff as motion_module
 
@@ -73,6 +74,20 @@ class AnimateDiffProcess:
         return list_var
 
 
+    def get_dict(self, is_img2img: bool):
+        dict_var = vars(self)
+        dict_var["mm_hash"] = motion_module.mm.mm_hash[:8]
+        dict_var.pop("video_source", None)
+        dict_var.pop("video_path", None)
+        dict_var.pop("last_frame", None)
+        if not is_img2img:
+            dict_var.pop("latent_power", None)
+            dict_var.pop("latent_scale", None)
+            dict_var.pop("latent_power_last", None)
+            dict_var.pop("latent_scale_last", None)
+        return dict_var
+
+
     def _check(self):
         assert (
             self.video_length >= 0 and self.fps > 0
@@ -82,7 +97,7 @@ class AnimateDiffProcess:
         ), "At least one saving format should be selected."
 
 
-    def set_p(self, p):
+    def set_p(self, p: StableDiffusionProcessing):
         self._check()
         if self.video_length < self.batch_size:
             p.batch_size = self.batch_size


### PR DESCRIPTION
This update list is tentative

The following items will be available in v1.9.2
- [x] sequential context generator
- [x] let first prompt affect last prompt interpolation when closed loop
- [x] png info - prompt travel, mm hash, etc
- [x] readme refactor

The following items will be available in v1.10.0
- [ ] i2i batch
- [ ] vram optimization

The following items will be in v1.10.1
- [ ] webp output format (merge #92)
- [ ] config pre-set
- [ ] [controlnet per-frame weights](https://cdn.discordapp.com/attachments/1145365129324675182/1161223403676631071/1399556488.mp4?ex=65378491&is=65250f91&hm=ca2aebbb71256347e2c1b139e699f937d6cbe347d47409063e41289a0c590baf&)
- [ ] prompt travel w/ ip-adapter
- [ ] fix any absolute path
- [ ] hints.js
- [ ] instruction video

The following items will be in an undefined update later, probably v1.11.0
- [ ] refactor [SAM](https://github.com/continue-revolution/sd-webui-segment-anything) to support video inpainting and automatic inpainting in-fly
- [ ] reference only
- [ ] support batch size ([KohakuBlueleaf](https://github.com/KohakuBlueleaf) will PR)
- [ ] #213
- [ ] recover from assertion error such as OOM without the need to re-start
- [ ] test upscale, refine, tile-upscale, stylize - monitor [cli](https://github.com/s9roll7/animatediff-cli-prompt-travel) update