### PR TITLE
Add WebP output with infotext stored in exif and options for quality

### DIFF
--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -106,6 +106,28 @@ def on_ui_settings():
         )
     )
     shared.opts.add_option(
+        "animatediff_webp_quality",
+        shared.OptionInfo(
+            80,
+            "WebP Quality (if lossless=True, increases compression and CPU usage)",
+            gr.Slider,
+            {
+                "minimum": 1,
+                "maximum": 100,
+                "step": 1},
+            section=section
+        )
+    )
+    shared.opts.add_option(
+        "animatediff_webp_lossless",
+        shared.OptionInfo(
+            False,
+            "Save WebP in lossless format (highest quality, largest file size)",
+            gr.Checkbox,
+            section=section
+        )
+    )
+    shared.opts.add_option(
         "animatediff_save_to_custom",
         shared.OptionInfo(
             False,

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -92,7 +92,7 @@ class AnimateDiffProcess:
         assert (
             self.video_length >= 0 and self.fps > 0
         ), "Video length and FPS should be positive."
-        assert not set(["GIF", "MP4", "PNG"]).isdisjoint(
+        assert not set(["GIF", "MP4", "PNG", "WEBP"]).isdisjoint(
             self.format
         ), "At least one saving format should be selected."
 
@@ -207,7 +207,7 @@ class AnimateDiffUiGroup:
                 )
             with gr.Row():
                 self.params.format = gr.CheckboxGroup(
-                    choices=["GIF", "MP4", "PNG", "TXT"],
+                    choices=["GIF", "MP4", "PNG", "TXT", "WEBP"],
                     label="Save format",
                     type="value",
                     elem_id=f"{elemid_prefix}save-format",


### PR DESCRIPTION
Add WebP output with options for lossless and quality.

* Quality and lossless settings are found in the Automatic1111 settings under the AnimateDiff section.
* Quality defaults to 95%. Lossless defaults to Off.
* When saving lossless, quality adjusts compression and increases CPU usage.
* Infotext is included and works with the PNG Info tab.

Based on #87 