### PR TITLE
Bug, pass -overwrite_original to exiftool

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -188,7 +188,7 @@ class AnimateDiffOutput:
                             exif_tool = exiftool.ExifTool()
                             with exif_tool:
                                 escaped_infotext = infotext.replace('\n', r'\n')
-                                exif_tool.execute(f"-Comment={escaped_infotext}", video_path_gif)
+                                exif_tool.execute("-overwrite_original", f"-Comment={escaped_infotext}", video_path_gif)
                         except FileNotFoundError:
                             logger.warn(
                                 "exiftool not found, required for infotext with optimized GIF palette, try: apt install libimage-exiftool-perl or https://exiftool.org/"

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -75,16 +75,18 @@ class AnimateDiffProcess:
 
 
     def get_dict(self, is_img2img: bool):
-        dict_var = vars(self)
+        dict_var = vars(self).copy()
         dict_var["mm_hash"] = motion_module.mm.mm_hash[:8]
-        dict_var.pop("video_source", None)
-        dict_var.pop("video_path", None)
-        dict_var.pop("last_frame", None)
+        dict_var.pop("enable")
+        dict_var.pop("format")
+        dict_var.pop("video_source")
+        dict_var.pop("video_path")
+        dict_var.pop("last_frame")
         if not is_img2img:
-            dict_var.pop("latent_power", None)
-            dict_var.pop("latent_scale", None)
-            dict_var.pop("latent_power_last", None)
-            dict_var.pop("latent_scale_last", None)
+            dict_var.pop("latent_power")
+            dict_var.pop("latent_scale")
+            dict_var.pop("latent_power_last")
+            dict_var.pop("latent_scale_last")
         return dict_var
 
 


### PR DESCRIPTION
Exiftool is saving the original file with _original appended to the extension. Pass the -overwrite_original parameter to avoid this.