### PR TITLE
Bug, handle saving WebP without infotext

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -220,6 +220,7 @@ class AnimateDiffOutput:
             if PIL.features.check('webp_anim'):            
                 video_path_webp = video_path_prefix + ".webp"
                 video_paths.append(video_path_webp)
+                exif_bytes = b''
                 if use_infotext:
                     exif_bytes = piexif.dump({
                         "Exif":{


### PR DESCRIPTION
For WebP output, set exif_bytes to null string to handle case where saving PNG Info is disabled.

Closes #249