### PR TITLE
For API , enable the returned images to support animated formats, such as GIF and WebP

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -22,6 +22,7 @@ class AnimateDiffOutput:
         logger.info("Merging images into GIF.")
         Path(f"{p.outpath_samples}/AnimateDiff").mkdir(exist_ok=True, parents=True)
         step = params.video_length if params.video_length > params.batch_size else params.batch_size
+        is_api_and_animated = p.is_api and ("GIF" in params.format or "WEBP" in params.format)
         for i in range(res.index_of_first_image, len(res.images), step):
             # frame interpolation replaces video_list with interpolated frames
             # so make a copy instead of a slice (reference), to avoid modifying res
@@ -33,7 +34,6 @@ class AnimateDiffOutput:
 
             image_list = self._add_reverse(params, image_list)
             image_list = self._interp(p, params, image_list, filename)
-            is_api_and_animated = p.is_api and ("GIF" in params.format or "WEBP" in params.format)
             if is_api_and_animated:
                 video_list += self._returnAnimatedImage(params, image_list, res, i)
             else:


### PR DESCRIPTION
For API , enable the returned images to support animated formats, such as GIF and WebP

Also need to modify the modules\api\api.py file to allow GIF and WebP encoding, change it in the encode_pil_to_base64 method."
```
def encode_pil_to_base64(image):
    with io.BytesIO() as output_bytes:
        if image.format is not None and image.format.lower() in ('gif', 'webp'):
            image.save(output_bytes, format=image.format, save_all=True)
        elif opts.samples_format.lower() == 'png':
......
```