### PR TITLE
hack to enforce start and end frame by modifying denoising strength p…

### DIFF
--- a/scripts/animatediff_infv2v.py
+++ b/scripts/animatediff_infv2v.py
@@ -187,6 +187,18 @@ class AnimateDiffInfV2V:
             if self.mask_before_denoising and self.mask is not None:
                 x = self.init_latent * self.mask + self.nmask * x
 
+
+            #MILES CHANGE
+            milesNumber = (1, 0.9,0.8,0.7,0.6,0.5,0.4,0.3,0.25,0.2,0.15,0.1,0.09,.08,.07,.06,.05,.04,.03,.02,.01, 0, 0, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1, 1, 1, 1, 1, 1)
+            
+            
+            for i in range(x.shape[0]):
+                if (self.step / state.sampling_steps) < milesNumber[i]: 
+                    x[i, :, :, :] = self.init_latent[i, :, :, :]
+            
+            #END MILES CHANGE
+
+
             batch_size = len(conds_list)
             repeats = [len(conds_list[i]) for i in range(batch_size)]
 


### PR DESCRIPTION
(as referenced in #96 )

While this method allows for the start and end frame to be exactly the input picture, there is a bit of temporal inconsistency (e.g., the colors). From what I can tell, the model is not actually trying to make the middle frames look like the start and end frames. 

If you set the "milesNumber" to (1, 0, 0, 0, 0, ...), it will force the initial frame to be the img2img input frame. Ideally, animateDiff would then try to make the following frames temporally consistent with this initial frame. But this is not the case (it seems to ignore the first un-denoised frame).

My understanding of the program is very limited, thanks very much for all your hard work!
