### PR TITLE
Update Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ You might also be interested in another extension I created: [Segment Anything f
 - `2023/11/10`: [v1.12.0](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.12.0): [AnimateDiff for SDXL](https://github.com/guoyww/AnimateDiff/tree/sdxl) supported. See [SDXL](#sdxl) for more information. You need to add `--disable-safe-unpickle` to your command line arguments to get rid of the bad file error.
 - `2023/11/16`: [v1.12.1](https://github.com/continue-revolution/sd-webui-animatediff/releases/tag/v1.12.1): FP8 precision and LCM sampler supported. See [Optimizations](#optimizations) for more information. You can also optionally upload videos to AWS S3 storage by configuring appropriately via `Settings/AnimateDiff AWS`.
 
-For future update plan, please query [here](https://github.com/continue-revolution/sd-webui-animatediff/pull/294).
-
 
 ## How to Use
 1. Update your WebUI to v1.6.0 and ControlNet to v1.1.410, then install this extension via link. I do not plan to support older version.


### PR DESCRIPTION
## Announcement

- - -
## Content
This PR serves as the plan and announcement for future updates. It will never be merged or closed.

This extension will serve as the A1111 version of video generation toolkit. For the time being, the majority of video generative models are based on AnimateDiff, but I don't believe that AnimateDiff is the final destination - there must be better model architectures.

A large version bump normally means new model support satisfying the following criteria:
- open-sourced video generative diffusion model, not limited to AnimateDiff itself
- proven to be high-performance / very popular (typically more than 1k GitHub stars or highly phrased within the community)
- you are encouraged to submit a feature request with new models and / or new features, but you need to pursuade me that it is actually needed. Whenever you encounter a new work, learn to doubt and experiment before getting too excited - the majority of academic works are 100% garbage.
- you are more encouraged to participate in coding and submit a PR to accelerate the development processed. I am paid to do something completely unrelated to video diffusion, and the development progress can never be guaranteed given my current situation.

A list of new models that might be worth supporting
- [ ] [Animate Anyone](https://github.com/HumanAIGC/AnimateAnyone) (Not open-sourced yet, but seems very exciting. They used AnimateDiff)
- [ ] [Stable Video Diffusion](https://github.com/Stability-AI/generative-models/commit/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9) (Most likely combined with a PR to A1111 + AnimateDiff -> SVD VAE)

A small version bump normally means new community features not “officially” supported but I think it is worth having (may come from myself or somewhere else).

A list of community features that might be worth supporting
- [ ] [MasaCtrl](https://github.com/TencentARC/MasaCtrl)
- [ ] [tokenflow](https://github.com/omerbt/TokenFlow)
- [ ] prompt travel w/ ip-adapter
- [ ] [controlnet per-frame weights](https://cdn.discordapp.com/attachments/1145365129324675182/1161223403676631071/1399556488.mp4?ex=65378491&is=65250f91&hm=ca2aebbb71256347e2c1b139e699f937d6cbe347d47409063e41289a0c590baf&)
- [ ] improve i2v (dive into denoising strength, probably see [here](https://github.com/guoyww/AnimateDiff/forks)) & i2v per-frame weights - is it possible to completely lock 0 & -1 frame? #251 
- [ ] [motion weight](https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved/commit/5bbcae4d226e8f298a8b204e9cc9b2dd41fbe417)
- [ ] [region prompt](https://github.com/s9roll7/animatediff-cli-prompt-travel/commit/6a017b4480f5472aa8b38ca77396c47d1411d6fe): from CLI / ComfyUI / MultiDiffusion / LatentCouple
- [ ] #236
- [ ] #259
- [ ] make sure that cli features work, especially upscale, refine, tile-upscale, stylize - monitor [cli](https://github.com/s9roll7/animatediff-cli-prompt-travel) update
- [ ] check some comfy workflows on reddit, discord and twitter
- [ ] #213
- [ ] batch size ([KohakuBlueleaf](https://github.com/KohakuBlueleaf) will PR)