### PR TITLE
Support infotext paste

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-scp -r * ryzen3600.int.orangelight.org:stable-diffusion-webui/extensions/sd-webui-animatediff/

--- a/copy.sh
+++ b/copy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+scp -r * ryzen3600.int.orangelight.org:stable-diffusion-webui/extensions/sd-webui-animatediff/

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -27,6 +27,8 @@ class AnimateDiffScript(scripts.Script):
         self.cn_hacker = None
         self.prompt_scheduler = None
         self.hacked = False
+        self.infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
+        self.paste_field_names: List[str] = []
 
 
     def title(self):
@@ -38,20 +40,12 @@ class AnimateDiffScript(scripts.Script):
 
 
     def ui(self, is_img2img):
-        ui_group = AnimateDiffUiGroup()
-        unit = ui_group.render(is_img2img, motion_module.get_model_dir())
-        ui_controls = ui_group.params.get_list(is_img2img)
-        
-        # Set up controls to be copy-pasted using infotext
-        infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
-        paste_field_names: List[str] = []
-        for control in ui_controls:
-            control_locator = f"AnimateDiff {control.label}"
-            infotext_fields.append((control, control_locator))
-            paste_field_names.append(control_locator)
-        self.infotext_fields = infotext_fields
-        self.paste_field_names = paste_field_names 
-        
+        unit = AnimateDiffUiGroup().render(
+            is_img2img,
+            motion_module.get_model_dir(),
+            self.infotext_fields,
+            self.paste_field_names
+        )
         return (unit,)
 
     def before_process(self, p: StableDiffusionProcessing, params: AnimateDiffProcess):

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -27,8 +27,6 @@ class AnimateDiffScript(scripts.Script):
         self.cn_hacker = None
         self.prompt_scheduler = None
         self.hacked = False
-        self.infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
-        self.paste_field_names: List[str] = []
 
 
     def title(self):
@@ -40,12 +38,20 @@ class AnimateDiffScript(scripts.Script):
 
 
     def ui(self, is_img2img):
-        unit = AnimateDiffUiGroup().render(
-            is_img2img,
-            motion_module.get_model_dir(),
-            self.infotext_fields,
-            self.paste_field_names
-        )
+        ui_group = AnimateDiffUiGroup()
+        unit = ui_group.render(is_img2img, motion_module.get_model_dir())
+        ui_controls = ui_group.params.get_list(is_img2img)
+        
+        # Set up controls to be copy-pasted using infotext
+        infotext_fields: List[Tuple[gr.components.IOComponent, str]] = []
+        paste_field_names: List[str] = []
+        for control in ui_controls:
+            control_locator = f"AnimateDiff {control.label}"
+            infotext_fields.append((control, control_locator))
+            paste_field_names.append(control_locator)
+        self.infotext_fields = infotext_fields
+        self.paste_field_names = paste_field_names 
+        
         return (unit,)
 
     def before_process(self, p: StableDiffusionProcessing, params: AnimateDiffProcess):

--- a/scripts/animatediff_infotext.py
+++ b/scripts/animatediff_infotext.py
@@ -28,8 +28,8 @@ def infotext_pasted(infotext, results):
             for items in v.split(', '):
                 field, value = items.split(': ')
                 results[f"AnimateDiff {field}"] = value
-        except Exception:
-            logger.warn(
-                f"Failed to parse infotext, legacy format infotext is no longer supported:\n{v}"
-            )
+            results.pop("AnimateDiff")
+        except Exception as e:
+            logger.warn(f"Failed to parse infotext value:\n{v}")
+            logger.warn(f"Exception: {e}")
         break

--- a/scripts/animatediff_infotext.py
+++ b/scripts/animatediff_infotext.py
@@ -23,7 +23,7 @@ def infotext_pasted(infotext, results):
         if not k.startswith("AnimateDiff"):
             continue
 
-        assert isinstance(v, str), f"Expect string but got {v}."
+        assert isinstance(v, str), f"Expected string but got {v}."
         try:
             for items in v.split(', '):
                 field, value = items.split(': ')

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -112,11 +112,11 @@ class AnimateDiffProcess:
         if not is_img2img:
             remove.extend(["latent_power", "latent_power_last", "latent_scale", "latent_scale_last"])
         
-        return (
+        return [
             field 
             for field in self.__dict__ 
             if field not in remove and not callable(getattr(self, field)) and not field.startswith("__")
-        )
+        ]
 
 
     def _check(self):
@@ -153,13 +153,7 @@ class AnimateDiffUiGroup:
         self.params = AnimateDiffProcess()
 
 
-    def render(
-        self,
-        is_img2img: bool,
-        model_dir: str,
-        infotext_fields,
-        paste_field_names
-    ):
+    def render(self, is_img2img: bool, model_dir: str, infotext_fields, paste_field_names):
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
         elemid_prefix = "img2img-ad-" if is_img2img else "txt2img-ad-"

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -98,10 +98,10 @@ class AnimateDiffProcess:
             infotext['mm_hash'] = motion_module.mm.mm_hash[:8]
         if is_img2img:
             infotext.update({
-                "latent_power": self.latent_power,
-                "latent_scale": self.latent_scale,
-                "latent_power_last": self.latent_power_last,
-                "latent_scale_last": self.latent_scale_last,
+                "Latent power": self.latent_power,
+                "Latent scale": self.latent_scale,
+                "Optional latent power for last frame": self.latent_power_last,
+                "Optional latent scale for last frame": self.latent_scale_last,
             })
         infotext_str = ', '.join(f"{k}: {v}" for k, v in infotext.items())
         return infotext_str

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -141,7 +141,13 @@ class AnimateDiffUiGroup:
         self.params = AnimateDiffProcess()
 
 
-    def render(self, is_img2img: bool, model_dir: str):
+    def render(
+        self,
+        is_img2img: bool,
+        model_dir: str,
+        infotext_fields,
+        paste_field_names
+    ):
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
         elemid_prefix = "img2img-ad-" if is_img2img else "txt2img-ad-"
@@ -313,6 +319,19 @@ class AnimateDiffUiGroup:
                 remove = gr.Button(value="Remove motion module from any memory")
                 unload.click(fn=motion_module.unload)
                 remove.click(fn=motion_module.remove)
+
+        # Set up controls to be copy-pasted using infotext
+        remove = ["format", "request_id", "video_source", "video_path", "last_frame"]
+        if not is_img2img:
+            remove.extend(["latent_power", "latent_power_last", "latent_scale", "latent_scale_last"])
+        fields = [
+            field 
+            for field in dir(self.params) 
+            if field not in remove and not callable(getattr(self.params, field)) and not field.startswith("__")
+        ]
+        infotext_fields.extend((getattr(self.params, field), f"AnimateDiff {field}") for field in fields)
+        paste_field_names.extend(f"AnimateDiff {field}" for field in fields)
+
         return self.register_unit(is_img2img)
 
 

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -80,17 +80,17 @@ class AnimateDiffProcess:
 
     def get_dict(self, is_img2img: bool):
         infotext = {
-            "Enable AnimateDiff": self.enable,
-            "Motion module": self.model,
-            "Number of frames": self.video_length,
-            "FPS": self.fps,
-            "Display loop number": self.loop_number,
-            "Closed loop": self.closed_loop,
-            "Context batch size": self.batch_size,
-            "Stride": self.stride,
-            "Overlap": self.overlap,
-            "Frame Interpolation": self.interp,
-            "Interp X": self.interp_x,
+            "enable": self.enable,
+            "model": self.model,
+            "video_length": self.video_length,
+            "fps": self.fps,
+            "loop_number": self.loop_number,
+            "closed_loop": self.closed_loop,
+            "batch_size": self.batch_size,
+            "stride": self.stride,
+            "overlap": self.overlap,
+            "interp": self.interp,
+            "interp_x": self.interp_x,
         }
         if self.request_id:
             infotext['request_id'] = self.request_id
@@ -98,10 +98,10 @@ class AnimateDiffProcess:
             infotext['mm_hash'] = motion_module.mm.mm_hash[:8]
         if is_img2img:
             infotext.update({
-                "Latent power": self.latent_power,
-                "Latent scale": self.latent_scale,
-                "Optional latent power for last frame": self.latent_power_last,
-                "Optional latent scale for last frame": self.latent_scale_last,
+                "latent_power": self.latent_power,
+                "latent_scale": self.latent_scale,
+                "latent_power_last": self.latent_power_last,
+                "latent_scale_last": self.latent_scale_last,
             })
         infotext_str = ', '.join(f"{k}: {v}" for k, v in infotext.items())
         return infotext_str

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -107,6 +107,18 @@ class AnimateDiffProcess:
         return infotext_str
 
 
+    def get_param_names(self, is_img2img: bool):
+        remove = ["format", "request_id", "video_source", "video_path", "last_frame"]
+        if not is_img2img:
+            remove.extend(["latent_power", "latent_power_last", "latent_scale", "latent_scale_last"])
+        
+        return (
+            field 
+            for field in self.__dict__ 
+            if field not in remove and not callable(getattr(self, field)) and not field.startswith("__")
+        )
+
+
     def _check(self):
         assert (
             self.video_length >= 0 and self.fps > 0
@@ -321,14 +333,7 @@ class AnimateDiffUiGroup:
                 remove.click(fn=motion_module.remove)
 
         # Set up controls to be copy-pasted using infotext
-        remove = ["format", "request_id", "video_source", "video_path", "last_frame"]
-        if not is_img2img:
-            remove.extend(["latent_power", "latent_power_last", "latent_scale", "latent_scale_last"])
-        fields = [
-            field 
-            for field in dir(self.params) 
-            if field not in remove and not callable(getattr(self.params, field)) and not field.startswith("__")
-        ]
+        fields = self.params.get_param_names(is_img2img)
         infotext_fields.extend((getattr(self.params, field), f"AnimateDiff {field}") for field in fields)
         paste_field_names.extend(f"AnimateDiff {field}" for field in fields)
 

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -80,17 +80,17 @@ class AnimateDiffProcess:
 
     def get_dict(self, is_img2img: bool):
         infotext = {
-            "enable": self.enable,
-            "model": self.model,
-            "video_length": self.video_length,
-            "fps": self.fps,
-            "loop_number": self.loop_number,
-            "closed_loop": self.closed_loop,
-            "batch_size": self.batch_size,
-            "stride": self.stride,
-            "overlap": self.overlap,
-            "interp": self.interp,
-            "interp_x": self.interp_x,
+            "Enable AnimateDiff": self.enable,
+            "Motion module": self.model,
+            "Number of frames": self.video_length,
+            "FPS": self.fps,
+            "Display loop number": self.loop_number,
+            "Closed loop": self.closed_loop,
+            "Context batch size": self.batch_size,
+            "Stride": self.stride,
+            "Overlap": self.overlap,
+            "Frame Interpolation": self.interp,
+            "Interp X": self.interp_x,
         }
         if self.request_id:
             infotext['request_id'] = self.request_id
@@ -98,10 +98,10 @@ class AnimateDiffProcess:
             infotext['mm_hash'] = motion_module.mm.mm_hash[:8]
         if is_img2img:
             infotext.update({
-                "latent_power": self.latent_power,
-                "latent_scale": self.latent_scale,
-                "latent_power_last": self.latent_power_last,
-                "latent_scale_last": self.latent_scale_last,
+                "Latent power": self.latent_power,
+                "Latent scale": self.latent_scale,
+                "Optional latent power for last frame": self.latent_power_last,
+                "Optional latent scale for last frame": self.latent_scale_last,
             })
         infotext_str = ', '.join(f"{k}: {v}" for k, v in infotext.items())
         return infotext_str
@@ -141,13 +141,7 @@ class AnimateDiffUiGroup:
         self.params = AnimateDiffProcess()
 
 
-    def render(
-        self,
-        is_img2img: bool,
-        model_dir: str,
-        infotext_fields,
-        paste_field_names
-    ):
+    def render(self, is_img2img: bool, model_dir: str):
         if not os.path.isdir(model_dir):
             os.mkdir(model_dir)
         elemid_prefix = "img2img-ad-" if is_img2img else "txt2img-ad-"
@@ -319,19 +313,6 @@ class AnimateDiffUiGroup:
                 remove = gr.Button(value="Remove motion module from any memory")
                 unload.click(fn=motion_module.unload)
                 remove.click(fn=motion_module.remove)
-
-        # Set up controls to be copy-pasted using infotext
-        remove = ["format", "request_id", "video_source", "video_path", "last_frame"]
-        if not is_img2img:
-            remove.extend(["latent_power", "latent_power_last", "latent_scale", "latent_scale_last"])
-        fields = [
-            field 
-            for field in dir(self.params) 
-            if field not in remove and not callable(getattr(self.params, field)) and not field.startswith("__")
-        ]
-        infotext_fields.extend((getattr(self.params, field), f"AnimateDiff {field}") for field in fields)
-        paste_field_names.extend(f"AnimateDiff {field}" for field in fields)
-
         return self.register_unit(is_img2img)
 
 

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -80,17 +80,17 @@ class AnimateDiffProcess:
 
     def get_dict(self, is_img2img: bool):
         infotext = {
-            "enable": self.enable,
-            "model": self.model,
-            "video_length": self.video_length,
-            "fps": self.fps,
-            "loop_number": self.loop_number,
-            "closed_loop": self.closed_loop,
-            "batch_size": self.batch_size,
-            "stride": self.stride,
-            "overlap": self.overlap,
-            "interp": self.interp,
-            "interp_x": self.interp_x,
+            "Enable AnimateDiff": self.enable,
+            "Motion module": self.model,
+            "Number of frames": self.video_length,
+            "FPS": self.fps,
+            "Display loop number": self.loop_number,
+            "Closed loop": self.closed_loop,
+            "Context batch size": self.batch_size,
+            "Stride": self.stride,
+            "Overlap": self.overlap,
+            "Frame Interpolation": self.interp,
+            "Interp X": self.interp_x,
         }
         if self.request_id:
             infotext['request_id'] = self.request_id


### PR DESCRIPTION
Enable loading AnimateDiff settings from infotext paste and Send to txt2img/img2img

Fully working with PNG and WEBP. GIF sends all settings, but the escaped newlines in the prompt prevent sending the prompt itself. 

PNG Info doesn't support MP4 and WEBM yet so the infotext must be pasted into the positive prompt box, followed by pressing the paste button (blue square with white arrow). Most video players should be able to show the infotext. In VLC, use Tools > Media Info. Exiftool can also display the infotext.

Closes #384 