### PR TITLE
fix mp4 encoding error

### DIFF
--- a/scripts/animatediff_output.py
+++ b/scripts/animatediff_output.py
@@ -218,8 +218,8 @@ class AnimateDiffOutput:
             except ImportError:
                 from launch import run_pip
                 run_pip(
-                    "install pyav",
-                    "sd-webui-animatediff MP4 save requirement: PyAV",
+                    "install imageio[pyav]",
+                    "sd-webui-animatediff MP4 save requirement: imageio[pyav]",
                 )
                 import av
             options = {


### PR DESCRIPTION
As discussed in #377, the latest `pyav` package (version 12.0.2) doesn't support the libx264 encoder. Since [L156](https://github.com/continue-revolution/sd-webui-animatediff/blob/master/scripts/animatediff_output.py#L156) will install `imageio[pyav]`, the error can not be reproduced if you saved the result in the GIF format before.

A Minimal, Reproducible Example:
```
# conda create -n av_test python=3.10
# conda activate av_test && pip install pyav

import av

print('h264' in av.codecs_available). # False

with av.open("test.mp4", mode="w") as container:
    stream = container.add_stream('libx264', rate=60)
# av.codec.codec.UnknownCodecError: libx264
```

Install `imageio[av]` will fix it.
```
# conda create -n av_test_1 python=3.10
# conda activate av_test_1 && pip install imageio[av]

import av

print('h264' in av.codecs_available)

with av.open("test.mp4", mode="w") as container:
    stream = container.add_stream('libx264', rate=60)
```
