### PR TITLE
:bug: Fix build cn model

### DIFF
--- a/scripts/animatediff_cn.py
+++ b/scripts/animatediff_cn.py
@@ -243,7 +243,8 @@ class AnimateDiffControl:
                 if unit.module in model_free_preprocessors:
                     model_net = None
                 else:
-                    model_net, _ = cn_script.load_control_model(p, unet, unit.model)
+                    control_model = cn_script.load_control_model(p, unet, unit.model)
+                    model_net = control_model.model if isinstance(control_model, tuple) else control_model
                     model_net.reset()
                     if model_net is not None and getattr(devices, "fp8", False) and not isinstance(model_net, PlugableIPAdapter):
                         for _module in model_net.modules():

--- a/scripts/animatediff_cn.py
+++ b/scripts/animatediff_cn.py
@@ -243,7 +243,7 @@ class AnimateDiffControl:
                 if unit.module in model_free_preprocessors:
                     model_net = None
                 else:
-                    model_net = cn_script.load_control_model(p, unet, unit.model)
+                    model_net, _ = cn_script.load_control_model(p, unet, unit.model)
                     model_net.reset()
                     if model_net is not None and getattr(devices, "fp8", False) and not isinstance(model_net, PlugableIPAdapter):
                         for _module in model_net.modules():


### PR DESCRIPTION
`load_control_model` in sd-webui-controlnet script now returns a tuple of (model_net, control_model_type). This PR fixes the issue caused by this return type change.