### PR TITLE
Forge - Add option for default save formats

### DIFF
--- a/scripts/animatediff_settings.py
+++ b/scripts/animatediff_settings.py
@@ -1,6 +1,7 @@
 import gradio as gr
 
 from modules import shared
+from scripts.animatediff_ui import supported_save_formats
 
 
 def on_ui_settings():
@@ -14,6 +15,16 @@ def on_ui_settings():
             gr.Textbox,
             section=section,
         ),
+    )
+    shared.opts.add_option(
+        "animatediff_default_save_formats",
+        shared.OptionInfo(
+            ["GIF", "PNG"],
+            "Default Save Formats",
+            gr.CheckboxGroup,
+            {"choices": supported_save_formats},
+            section=section
+        ).needs_restart()
     )
     shared.opts.add_option(
         "animatediff_optimize_gif_palette",

--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -8,6 +8,7 @@ from modules.processing import StableDiffusionProcessing, StableDiffusionProcess
 
 from scripts.animatediff_mm import mm_animatediff as motion_module
 
+supported_save_formats = ["GIF", "MP4", "WEBP", "WEBM", "PNG", "TXT"]
 
 class ToolButton(gr.Button, gr.components.FormComponent):
     """Small button with single emoji as text, fits inside gradio forms"""
@@ -33,7 +34,7 @@ class AnimateDiffProcess:
         batch_size=16,
         stride=1,
         overlap=-1,
-        format=["GIF", "PNG"],
+        format=shared.opts.data.get("animatediff_default_save_formats", ["GIF", "PNG"]),
         interp='Off',
         interp_x=10,
         video_source=None,
@@ -205,7 +206,7 @@ class AnimateDiffUiGroup:
                     refresh_model.click(refresh_models, self.params.model, self.params.model)
 
                 self.params.format = gr.CheckboxGroup(
-                    choices=["GIF", "MP4", "WEBP", "WEBM", "PNG", "TXT"],
+                    choices=supported_save_formats,
                     label="Save format",
                     type="value",
                     elem_id=f"{elemid_prefix}save-format",


### PR DESCRIPTION
I've noticed there is assert line with almost the same hardcoded extensions list, except "TXT". When you will add new file formats, it should be taken into account