### PR TITLE
V2.0.0a api fix #2 - refix the broken API pipeline

### DIFF
--- a/scripts/animatediff_ui.py
+++ b/scripts/animatediff_ui.py
@@ -186,7 +186,7 @@ class AnimateDiffProcess:
                 cn_unit.batch_mask_dir = self.mask_path
 
             # find minimun control images in CN batch
-            cn_unit_batch_params = cn_unit.batch_images.split('\n')
+            cn_unit_batch_params = cn_unit.batch_images.split('\n') if cn_unit.batch_images is not None else []
             if cn_unit.input_mode.name == 'BATCH':
                 cn_unit.animatediff_batch = True # for A1111 sd-webui-controlnet
                 if not any([cn_param.startswith("keyframe:") for cn_param in cn_unit_batch_params[1:]]):

--- a/scripts/animatediff_utils.py
+++ b/scripts/animatediff_utils.py
@@ -55,7 +55,7 @@ def get_controlnet_units(p: StableDiffusionProcessing):
     for script in p.scripts.alwayson_scripts:
         if script.title().lower() == "controlnet":
             cn_units = p.script_args[script.args_from:script.args_to]
-            #print(cn_units)
+
             if p.is_api and len(cn_units) > 0 and isinstance(cn_units[0], dict):
                from scripts import external_code
                from scripts.batch_hijack import InputMode

--- a/scripts/animatediff_utils.py
+++ b/scripts/animatediff_utils.py
@@ -9,7 +9,6 @@ from modules.processing import StableDiffusionProcessing
 
 from scripts.animatediff_logger import logger_animatediff as logger
 
-
 def generate_random_hash(length=8):
     import hashlib
     import secrets
@@ -40,6 +39,7 @@ def get_animatediff_arg(p: StableDiffusionProcessing):
             if isinstance(animatediff_arg, dict):
                 from scripts.animatediff_ui import AnimateDiffProcess
                 animatediff_arg = AnimateDiffProcess(**animatediff_arg)
+                p.script_args = list(p.script_args)
                 p.script_args[script.args_from] = animatediff_arg
             return animatediff_arg
 
@@ -55,7 +55,20 @@ def get_controlnet_units(p: StableDiffusionProcessing):
     for script in p.scripts.alwayson_scripts:
         if script.title().lower() == "controlnet":
             cn_units = p.script_args[script.args_from:script.args_to]
-            return [x for x in cn_units if x.enabled]
+            #print(cn_units)
+            if p.is_api and len(cn_units) > 0 and isinstance(cn_units[0], dict):
+               from scripts import external_code
+               from scripts.batch_hijack import InputMode
+               cn_units = external_code.get_all_units_in_processing(p)
+               for cn_unit in cn_units:
+                  setattr(cn_unit, "input_mode", InputMode.BATCH)
+                  setattr(cn_unit, "batch_images", None)
+                  setattr(cn_unit, "batch_mask_dir", None)
+                  setattr(cn_unit, "batch_input_gallery", None)
+                  setattr(cn_unit, "batch_modifiers", [])
+                  setattr(cn_unit, "animatediff_batch", True)
+               p.script_args[script.args_from:script.args_to] = cn_units
+            return [x for x in cn_units if x.enabled] if not p.is_api else cn_units
 
     return []
 

--- a/scripts/animatediff_utils.py
+++ b/scripts/animatediff_utils.py
@@ -57,17 +57,28 @@ def get_controlnet_units(p: StableDiffusionProcessing):
             cn_units = p.script_args[script.args_from:script.args_to]
 
             if p.is_api and len(cn_units) > 0 and isinstance(cn_units[0], dict):
-               from scripts import external_code
-               from scripts.batch_hijack import InputMode
-               cn_units = external_code.get_all_units_in_processing(p)
-               for cn_unit in cn_units:
-                  setattr(cn_unit, "input_mode", InputMode.BATCH)
-                  setattr(cn_unit, "batch_images", None)
-                  setattr(cn_unit, "batch_mask_dir", None)
-                  setattr(cn_unit, "batch_input_gallery", None)
-                  setattr(cn_unit, "batch_modifiers", [])
-                  setattr(cn_unit, "animatediff_batch", True)
-               p.script_args[script.args_from:script.args_to] = cn_units
+                from scripts import external_code
+                from scripts.batch_hijack import InputMode
+                cn_units_dataclass = external_code.get_all_units_in_processing(p)
+                for cn_unit_dict, cn_unit_dataclass in zip(cn_units, cn_units_dataclass):
+                    # NB: Unfortunately this setattr section is required because those attributes don't exist
+                    # in the default ControlNetUnit class defined in sd-webui-controlnet library.
+                    # So we have to use this hack to append extra batch processing related attributes to the object 
+                    # until sd-webui-controlnet makes an update.
+                    setattr(cn_unit_dataclass, "input_mode", InputMode.SIMPLE)
+                    setattr(cn_unit_dataclass, "batch_images", None)
+                    setattr(cn_unit_dataclass, "batch_mask_dir", None)
+                    setattr(cn_unit_dataclass, "batch_input_gallery", None)
+                    setattr(cn_unit_dataclass, "batch_modifiers", [])
+                    setattr(cn_unit_dataclass, "animatediff_batch", False)
+                    
+                    if cn_unit_dataclass.image is None:
+                        cn_unit_dataclass.input_mode = InputMode.BATCH
+                        cn_unit_dataclass.batch_images = cn_unit_dict.get("batch_images", None)
+                        cn_unit_dataclass.animatediff_batch = True
+
+                p.script_args[script.args_from:script.args_to] = cn_units_dataclass
+                cn_units = cn_units_dataclass
             return [x for x in cn_units if x.enabled] if not p.is_api else cn_units
 
     return []


### PR DESCRIPTION
The commit of https://github.com/continue-revolution/sd-webui-animatediff/pull/468 seems to break the APi pipelines again.

The primary cause of the problem is that "setattr" sections cannot be removed as those extra attributes don't exist in the default ControlNetUnit class defined in sd-webui-controlnet, and "setattr" will add the new attributes (which only exist in the UiControlNet class) to the object in a hacky way. To remove them, there will need to be a change in the sd-webui-control which I don't bother to make right now.

Another bug is that the return of the get_controlnet_units should be cn_units_dataclass (a list of ControlNetUnit) when is_api is True

