### PR TITLE
Update xyz module detecction

### DIFF
--- a/scripts/animatediff_xyz.py
+++ b/scripts/animatediff_xyz.py
@@ -119,7 +119,7 @@ def choices_bool():
 
 def find_xyz_module() -> Optional[ModuleType]:
     for data in scripts.scripts_data:
-        if data.script_class.__module__ in {"xyz_grid.py", "xy_grid.py"} and hasattr(data, "module"):
+        if data.script_class.__module__ in {"xyz_grid.py", "xy_grid.py", "scripts.xyz_grid", "scripts.xy_grid"} and hasattr(data, "module"):
             return data.module
 
     return None


### PR DESCRIPTION
`script_class.__module__` is changed from `foo.py` to `scripts.foo` in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15532#issuecomment-2068006783.

This PR updates the `__module__` matching.